### PR TITLE
Update node-releases

### DIFF
--- a/index.js
+++ b/index.js
@@ -695,7 +695,8 @@ var QUERIES = [
     select: function (context) {
       var now = Date.now()
       var queries = Object.keys(jsEOL).filter(function (key) {
-        return now < Date.parse(jsEOL[key].end)
+        return now < Date.parse(jsEOL[key].end) &&
+          now > Date.parse(jsEOL[key].start)
       }).map(function (key) {
         return 'node ' + key.slice(1)
       })

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "8.5 KB"
+      "limit": "8.511 KB"
     }
   ],
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "caniuse-lite": "^1.0.30000865",
     "electron-to-chromium": "^1.3.52",
-    "node-releases": "^1.0.0-alpha.10"
+    "node-releases": "^1.0.0-alpha.11"
   },
   "bin": "./cli.js",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3800,9 +3800,9 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.0.0-alpha.10:
-  version "1.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.0-alpha.10.tgz#61c8d5f9b5b2e05d84eba941d05b6f5202f68a2a"
+node-releases@^1.0.0-alpha.11:
+  version "1.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.0-alpha.11.tgz#73c810acc2e5b741a17ddfbb39dfca9ab9359d8a"
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
Also Node 11 release date was added to schedule so we need to filter out it from list of maintained versions by checking that `Date.now()` is bigger than (future) release timestamp.