### PR TITLE
Moving package.json query to the top of the queries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ You can test Browserslist queries in [online demo].
 Browserslist will use browsers and Node.js versions query
 from one of this sources:
 
+1. `browserslist` key in `package.json` file in current or parent directories.
+   **We recommend this way.**
 1. Tool options. For example `browsers` option in Autoprefixer.
 2. `BROWSERSLIST` environment variable.
 3. `browserslist` config file in current or parent directories.
 3. `.browserslistrc` config file in current or parent directories.
-4. `browserslist` key in `package.json` file in current or parent directories.
-   **We recommend this way.**
 5. If the above methods did not produce a valid result
    Browserslist will use defaults:
    `> 0.5%, last 2 versions, Firefox ESR, not dead`.


### PR DESCRIPTION
Since it's recommended it should be at the top. Even though it's bold not every one will read the `We recommend this way.` note.