### PR TITLE
--all CLI Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.2
+* Add --all command line option
+
 ## 4.1.1
 * Update Firefox ESR versions.
 

--- a/cli.js
+++ b/cli.js
@@ -91,21 +91,20 @@ if (isArg('--help') || isArg('-h')) {
     browsers.forEach(function (browser) {
       process.stdout.write(browser + '\n')
     })
-    var stats
-    var worldResult = browserslist.coverage(browsers, stats)
+    var worldResult = browserslist.coverage(browsers, undefined)
     var roundWorld = Math.round(worldResult * 100) / 100.0
     process.stdout.write('coverage_global ' + roundWorld + '\n')
 
     var usResult = browserslist.coverage(browsers, 'us')
     var roundUS = Math.round(usResult * 100) / 100.0
     process.stdout.write('coverage_us ' + roundUS + '\n')
-  }
-  else if (mode === 'browsers') {
+
+  } else if (mode === 'browsers') {
     browsers.forEach(function (browser) {
       process.stdout.write(browser + '\n')
     })
-  } 
-  else {
+
+  } else {
     var stats
     if (country) {
       stats = country

--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ var USAGE = 'Usage:\n' +
             '  ' + pkg.name + ' --coverage=US "QUERIES"\n' +
             '  ' + pkg.name + ' --env="environment name defined in config"\n' +
             '  ' + pkg.name + ' --stats="path/to/browserlist/stats/file"' +
-            '  ' + pkg.name + ' --all (returns browsers and coverage info)"\n' +
+            '  ' + pkg.name + ' --all (returns browsers and coverage info)"\n'
 
 function isArg (arg) {
   return args.some(function (str) {
@@ -91,12 +91,12 @@ if (isArg('--help') || isArg('-h')) {
     browsers.forEach(function (browser) {
       process.stdout.write(browser + '\n')
     })
-
-    var worldResult = browserslist.coverage(browsers, null)
+    var stats
+    var worldResult = browserslist.coverage(browsers, stats)
     var roundWorld = Math.round(worldResult * 100) / 100.0
     process.stdout.write('coverage_global ' + roundWorld + '\n')
 
-    var usResult = browserslist.coverage(browsers, "us")
+    var usResult = browserslist.coverage(browsers, 'us')
     var roundUS = Math.round(usResult * 100) / 100.0
     process.stdout.write('coverage_us ' + roundUS + '\n')
   }

--- a/cli.js
+++ b/cli.js
@@ -98,12 +98,10 @@ if (isArg('--help') || isArg('-h')) {
     var usResult = browserslist.coverage(browsers, 'us')
     var roundUS = Math.round(usResult * 100) / 100.0
     process.stdout.write('coverage_us ' + roundUS + '\n')
-
   } else if (mode === 'browsers') {
     browsers.forEach(function (browser) {
       process.stdout.write(browser + '\n')
     })
-
   } else {
     var stats
     if (country) {

--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,8 @@ var USAGE = 'Usage:\n' +
             '  ' + pkg.name + ' --coverage "QUERIES"\n' +
             '  ' + pkg.name + ' --coverage=US "QUERIES"\n' +
             '  ' + pkg.name + ' --env="environment name defined in config"\n' +
-            '  ' + pkg.name + ' --stats="path/to/browserlist/stats/file"'
+            '  ' + pkg.name + ' --stats="path/to/browserlist/stats/file"' +
+            '  ' + pkg.name + ' --all (returns browsers and coverage info)"\n' +
 
 function isArg (arg) {
   return args.some(function (str) {
@@ -57,6 +58,8 @@ if (isArg('--help') || isArg('-h')) {
     } else if (name === '--coverage' || name === '-c') {
       mode = 'coverage'
       if (value) country = value
+    } else if (name === '--all' || name === '-a') {
+      mode = 'all'
     } else {
       error('Unknown arguments ' + args[i] + '.\n\n' + USAGE)
     }
@@ -84,11 +87,25 @@ if (isArg('--help') || isArg('-h')) {
     }
   }
 
-  if (mode === 'browsers') {
+  if (mode === 'all') {
     browsers.forEach(function (browser) {
       process.stdout.write(browser + '\n')
     })
-  } else {
+
+    var worldResult = browserslist.coverage(browsers, null)
+    var roundWorld = Math.round(worldResult * 100) / 100.0
+    process.stdout.write('coverage_global ' + roundWorld + '\n')
+
+    var usResult = browserslist.coverage(browsers, "us")
+    var roundUS = Math.round(usResult * 100) / 100.0
+    process.stdout.write('coverage_us ' + roundUS + '\n')
+  }
+  else if (mode === 'browsers') {
+    browsers.forEach(function (browser) {
+      process.stdout.write(browser + '\n')
+    })
+  } 
+  else {
     var stats
     if (country) {
       stats = country

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserslist",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Share target browsers between different front-end tools, like Autoprefixer, Stylelint and babel-env-preset",
   "keywords": [
     "caniuse",


### PR DESCRIPTION
As proposed in #297, this implements an `--all` flag on the CLI to return both the supported browsers and US/Global coverage values.

Implemented in a non-breaking way so that users who do not pass `--all` will still get the same output they did before. 