### PR TITLE
Extend query keywords with new keyword to match all browser versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ from one of this sources:
 
 You can specify the browser and Node.js versions by queries (case insensitive):
 
+* `all`: match all browsers versions.
 * `> 5%`: browsers versions selected by global usage statistics.
   `>=`, `<` and `<=` work too.
 * `> 5% in US`: uses USA usage statistics. It accepts [two-letter country code].

--- a/index.js
+++ b/index.js
@@ -759,6 +759,25 @@ var QUERIES = [
     }
   },
   {
+    regexp: /^all$/i,
+    select: function () {
+      var result = []
+      Object.keys(browserslist.data)
+        .map(function (x) {
+          var browser = byName(x)
+          var browserVersions = browser.versions || []
+          result = result.concat(browserVersions
+            .filter(function (browserVersion) {
+              return browserVersion && browserVersion.length
+            })
+            .map(function (browserVersion) {
+              return browser.name + ' ' + browserVersion
+            }))
+        })
+      return result
+    }
+  },
+  {
     regexp: /^(\w+)$/i,
     select: function (context, name) {
       if (byName(name)) {

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -1,0 +1,50 @@
+var browserslist = require('../')
+
+var originData = browserslist.data
+
+beforeEach(() => {
+  browserslist.data = {
+    ie: {
+      name: 'ie',
+      released: ['9', '10', '11'],
+      versions: ['9', '10', '11']
+    },
+    edge: {
+      name: 'edge',
+      released: ['12'],
+      versions: ['12', '13']
+    },
+    chrome: {
+      name: 'chrome',
+      released: ['37', '38', '39'],
+      versions: ['37', '38', '39', '40']
+    },
+    bb: {
+      name: 'bb',
+      released: ['8'],
+      versions: ['8']
+    },
+    firefox: {
+      released: []
+    }
+  }
+})
+
+afterEach(() => {
+  browserslist.data = originData
+})
+
+it('selects all versions of each browser', () => {
+  expect(browserslist('all')).toEqual([
+    'bb 8',
+    'chrome 40',
+    'chrome 39',
+    'chrome 38',
+    'chrome 37',
+    'edge 13',
+    'edge 12',
+    'ie 11',
+    'ie 10',
+    'ie 9'
+  ])
+})


### PR DESCRIPTION
Hello there,

Recently I was forced to use the browserslist configuration that excludes some browsers from all browsers versions instead to include some browser versions from the list of all browsers versions.

I read the documentation and didn't found the solution for this, so this PR includes the extension described above. Now we can do something like this:

```
all
not ie <= 9
not ios <= 8
```

The configuration above will exclude all versions of IE before the IE 10 and all versions of IOS before the IOS 9.

Please let me know if this could be merged into the main browserslist repo and if there any other changes required for this.