### PR TITLE
Possible resolution of #311

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,16 @@ var env = require('./node') // Will load browser.js in webpack
 
 var FLOAT_RANGE = /^\d+(\.\d+)?(-\d+(\.\d+)?)*$/
 
+function isVersionsMatch (versionA, versionB) {
+  return (versionA + '.').indexOf(versionB + '.') === 0
+}
+
+function isJsEolReleased (version) {
+  return jsReleases.some(function (i) {
+    return isVersionsMatch(i.version, version.slice(1))
+  })
+}
+
 function normalize (versions) {
   return versions.filter(function (version) {
     return typeof version === 'string'
@@ -680,7 +690,7 @@ var QUERIES = [
         return i.name === 'nodejs'
       })
       var matched = nodeReleases.filter(function (i) {
-        return (i.version + '.').indexOf(version + '.') === 0
+        return isVersionsMatch(i.version, version)
       })
       if (matched.length === 0) {
         if (context.ignoreUnknownVersions) {
@@ -705,7 +715,8 @@ var QUERIES = [
       var now = Date.now()
       var queries = Object.keys(jsEOL).filter(function (key) {
         return now < Date.parse(jsEOL[key].end) &&
-          now > Date.parse(jsEOL[key].start)
+          now > Date.parse(jsEOL[key].start) &&
+          isJsEolReleased(key)
       }).map(function (key) {
         return 'node ' + key.slice(1)
       })


### PR DESCRIPTION
https://github.com/browserslist/browserslist/issues/311#issuecomment-432126592

> Seems browserslist firstly get all versions by user's query (maintained node versions), then checks this versions separately:
> 
> maintained node versions -> ..., v10, v11 (https://github.com/browserslist/browserslist/blob/master/index.js#L706, https://raw.githubusercontent.com/nodejs/Release/master/schedule.json, v11 is exist)
> node 10 -> OK
> node 11 -> ERROR (https://github.com/browserslist/browserslist/blob/master/index.js#L679, https://nodejs.org/dist/index.json, v11 - doesn't exist)

Solution: check EOL version is in released versions.