### PR TITLE
Relax validation when extending config from scoped packages

### DIFF
--- a/node.js
+++ b/node.js
@@ -6,7 +6,7 @@ var BrowserslistError = require('./error')
 
 var IS_SECTION = /^\s*\[(.+)\]\s*$/
 var CONFIG_PATTERN = /^browserslist-config-/
-var SCOPED_CONFIG__PATTERN = /@[^./]+\/browserslist-config(-|$|\/)/
+var SCOPED_CONFIG__PATTERN = /@[^/]+\/browserslist-config(-|$|\/)/
 var TIME_TO_UPDATE_CANIUSE = 6 * 30 * 24 * 60 * 60 * 1000
 var FORMAT = 'Browserslist config should be a string or an array ' +
              'of strings with browser queries'
@@ -14,14 +14,13 @@ var FORMAT = 'Browserslist config should be a string or an array ' +
 var dataTimeChecked = false
 var filenessCache = { }
 var configCache = { }
-
 function checkExtend (name) {
   var use = ' Use `dangerousExtend` option to disable.'
   if (!CONFIG_PATTERN.test(name) && !SCOPED_CONFIG__PATTERN.test(name)) {
     throw new BrowserslistError(
       'Browserslist config needs `browserslist-config-` prefix. ' + use)
   }
-  if (name.indexOf('.') !== -1) {
+  if (name.replace(/^@[^/]+\//, '').indexOf('.') !== -1) {
     throw new BrowserslistError(
       '`.` not allowed in Browserslist config name. ' + use)
   }

--- a/test/extends.test.js
+++ b/test/extends.test.js
@@ -50,6 +50,13 @@ it('handles scoped packages', () => {
   })
 })
 
+it('handles scoped packages with a dot in the name', () => {
+  return mock('@example.com/browserslist-config-test', ['ie 11']).then(() => {
+    var result = browserslist(['extends @example.com/browserslist-config-test'])
+    expect(result).toEqual(['ie 11'])
+  })
+})
+
 it('handles file in scoped packages', () => {
   return mock('@scope/browserslist-config-test/ie', ['ie 11']).then(() => {
     var result = browserslist(['extends @scope/browserslist-config-test/ie'])


### PR DESCRIPTION
**TLDR:** The `SCOPED_CONFIG__PATTERN` regex and the '`.` not allowed in Browserslist config name.' rules disallowed extending a browserslist from a package called `@example.com/browserslist-config` even though that is a perfectly valid name for a scoped package.

I loosened up the regex `SCOPED_CONFIG__PATTERN` so it would match an npm org named example.com and modifed the other rule to remove a scope before it checks for dots in the extend reference.

----

I tried to create a sharable configuration for my employers internal project. I wanted it to publish it as a private package on npm, under our company scope. The company scope is our domain name, (e.g. @example.com/) but I found that it was rejected due to a rule that disallowed any extends-reference with a dot in it.

https://github.com/browserslist/browserslist/blob/7f37ae1d140d16938095500749da17d6268d4fbb/node.js#L24-L27

That is too restrictive as it disallows perfectly valid npm organisation names. [npm/validate-npm-package-name](https://github.com/npm/validate-npm-package-name) reveals what npm do (at least in their cli).

https://github.com/npm/validate-npm-package-name/blob/9ee8d54e28204b762f11451cf01207a3dc6be679/index.js#L76-L85

They use the following RegExp to validate scoped packages: `/^(?:@([^/]+?)[/])?([^/]+?)$/` and then proceed to check that the result of calling `encodeURIComponent` on both the scope name and package name does not change the input.

All of these, are real existing orgs on npm:
- https://www.npmjs.com/org/0123456789abcdefghijklmnopqrstuvwxyz-_.!*'()
- [https://www.npmjs.com/org/canitendwitha.](https://www.npmjs.com/org/canitendwitha.)
- [https://www.npmjs.com/org/~](https://www.npmjs.com/org/~)
- [https://www.npmjs.com/org/\_\_(-.-)\_\_](https://www.npmjs.com/org/__(-.-)__)

Rather than reimplementing their logic here, I relaxed `SCOPED_CONFIG__PATTERN` to match the intent of `scopedPackagePattern` from `validate-npm-package-name`.