### PR TITLE
Add `defaults` configuration example in Readme.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Developers set versions list in queries like `last 2 version`
 to be free from updating versions manually.
 Browserslist will use [Can I Use] data for this queries.
 
+There is also a `defaults` setting, which gives a reasonable configuration for most users.
+```json
+{
+  "browserslist": [
+    "defaults"
+  ]
+}
+```
+
 Browserslist will take queries from tool option,
 `browserslist` config, `.browserslistrc` config,
 `browserslist` section in `package.json` or environment variables.


### PR DESCRIPTION
This adds an example of a `defaults` configuration to the readme. I think the readme could additionally be improved by moving `defaults` to the top of the options list since it could be a starting point for most users. It could also use a slightly more detailed description. (How is this default arrived at?)

Closes #366.