### PR TITLE
Alias mobile browsers to the desktop version

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,9 @@ Options:
   Default is `false.`
 * `dangerousExtend`: Disable security checks for `extend` query.
   Default is `false.`
+* `mobileToDesktop`: Alias mobile browsers to the desktop version when Can I
+  Use doesn't have data about the specified version.
+  Default is `false`.
 
 For non-JS environment and debug purpose you can use CLI tool:
 

--- a/index.js
+++ b/index.js
@@ -136,11 +136,24 @@ function compareSemver (a, b) {
   )
 }
 
-function normalizeVersion (data, version) {
+function resolveVersion (data, version) {
   if (data.versions.indexOf(version) !== -1) {
     return version
   } else if (browserslist.versionAliases[data.name][version]) {
     return browserslist.versionAliases[data.name][version]
+  } else {
+    return false
+  }
+}
+
+function normalizeVersion (data, version) {
+  var resolved = resolveVersion(data, version)
+  if (!resolved && browserslist.fallbackAliases[data.name]) {
+    var alias = checkName(browserslist.fallbackAliases[data.name])
+    resolved = resolveVersion(alias, version)
+  }
+  if (resolved) {
+    return resolved
   } else if (data.versions.length === 1) {
     return data.versions[0]
   } else {
@@ -425,6 +438,15 @@ browserslist.aliases = {
   firefoxandroid: 'and_ff',
   ucandroid: 'and_uc',
   qqandroid: 'and_qq'
+}
+
+// Can I Use only provides a few versions for some browsers (e.g. and_chr).
+// Fallback to a similar browser for unknown versions
+browserslist.fallbackAliases = {
+  and_chr: 'chrome',
+  and_ff: 'firefox',
+  ie_mob: 'ie',
+  opera_mob: 'opera'
 }
 
 // Aliases to work with joined versions like `ios_saf 7.0-7.1`

--- a/test/direct.test.js
+++ b/test/direct.test.js
@@ -53,5 +53,16 @@ it('supports Can I Use cutted versions', () => {
 })
 
 it('supports Can I Use missing mobile versions', () => {
-  expect(browserslist('chromeandroid 53')).toEqual(['and_chr 53'])
+  var opts = { mobileToDesktop: true }
+  expect(browserslist('chromeandroid 53', opts)).toEqual(['and_chr 53'])
+  expect(browserslist('and_ff 60', opts)).toEqual(['and_ff 60'])
+  expect(browserslist('ie_mob 9', opts)).toEqual(['ie_mob 9'])
+  expect(browserslist('op_mob 30', opts)).toEqual(['op_mob 30'])
+})
+
+it('missing mobile versions are not aliased by default', () => {
+  expect(browserslist('chromeandroid 53')).not.toEqual(['and_chr 53'])
+  expect(browserslist('and_ff 60')).not.toEqual(['and_ff 60'])
+  expect(() => browserslist('ie_mob 9')).toThrow()
+  expect(() => browserslist('op_mob 30')).toThrow()
 })

--- a/test/direct.test.js
+++ b/test/direct.test.js
@@ -49,5 +49,9 @@ it('supports Safari TP', () => {
 })
 
 it('supports Can I Use cutted versions', () => {
-  expect(browserslist('and_chr 55')).toHaveLength(1)
+  expect(browserslist('and_uc 10')).toHaveLength(1)
+})
+
+it('supports Can I Use missing mobile versions', () => {
+  expect(browserslist('chromeandroid 53')).toEqual(['and_chr 53'])
 })


### PR DESCRIPTION
Fixes #367

In this PR, browserslist fallback to the desktop version only if the query doesn't match a mobile version. I didn't choose to always fallback in case a mobile browser has a release which doesn't match its desktop counterpart (is it even possible?).