### PR TITLE
Match desktop Chrome for evergreen Android WebView versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -966,19 +966,40 @@ var QUERIES = [
 // Get and convert Can I Use data
 
 (function () {
+  function getVersions (name) {
+    if (name !== 'android') {
+      return agents[name].versions
+    } else {
+      // Match desktop Chrome for evergreen Android WebView versions
+      var firstEvergreenVersion = 37
+      var beforeEvergreen = agents[name].versions.filter(function (v) {
+        return parseInt(v) < firstEvergreenVersion
+      })
+      var afterEvergreen = agents.chrome.versions
+        .slice(0, -3)
+        .filter(function (v) {
+          return parseInt(v) >= firstEvergreenVersion
+        })
+      return beforeEvergreen
+        .concat(afterEvergreen)
+        .concat([null, null, null])
+    }
+  }
+
   for (var name in agents) {
     var browser = agents[name]
+    var versions = getVersions(name)
     browserslist.data[name] = {
       name: name,
-      versions: normalize(agents[name].versions),
-      released: normalize(agents[name].versions.slice(0, -3)),
+      versions: normalize(versions),
+      released: normalize(versions.slice(0, -3)),
       releaseDate: agents[name].release_date
     }
     fillUsage(browserslist.usage.global, name, browser.usage_global)
 
     browserslist.versionAliases[name] = { }
-    for (var i = 0; i < browser.versions.length; i++) {
-      var full = browser.versions[i]
+    for (var i = 0; i < versions.length; i++) {
+      var full = versions[i]
       if (!full) continue
 
       if (full.indexOf('-') !== -1) {

--- a/test/direct.test.js
+++ b/test/direct.test.js
@@ -66,3 +66,11 @@ it('missing mobile versions are not aliased by default', () => {
   expect(() => browserslist('ie_mob 9')).toThrow()
   expect(() => browserslist('op_mob 30')).toThrow()
 })
+
+it('handles transition to evergreen android webview versions', () => {
+  expect(browserslist('android 4.4.4')).toEqual(['android 4.4.3-4.4.4'])
+  expect(() => browserslist('android 5')).toThrow()
+  expect(() => browserslist('android 36')).toThrow()
+  expect(browserslist('android 37')).toEqual(['android 37'])
+  expect(browserslist('android 38')).toEqual(['android 38'])
+})


### PR DESCRIPTION
Fix #374 

I did some digging into the MDN [browser-compat-data](https://github.com/mdn/browser-compat-data) for a second opinion on version history for the Android WebView. Based on this it appears a more complete way to account for missing version numbers in the `caniuse` data (short of using the MDN data directly) would be to match the version numbers after the Android WebView went evergreen (version 37) with desktop Chrome. 

https://github.com/mdn/browser-compat-data/blob/master/browsers/webview_android.json
https://github.com/mdn/browser-compat-data/blob/master/browsers/chrome.json

This gets `last N versions` and related queries working correctly and resolves another issue with `caniuse` data currently being about seven versions behind the current version of the Android WebView.

This reliable of a relationship between versions doesn't necessarily apply to all mobile browsers, so I left the recently added `mobileToDesktop` mapping untouched.