### PR TITLE
implement support for patch versions of Electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,17 @@ function normalize (versions) {
   })
 }
 
+function normalizeElectron (version) {
+  var versionToUse = version
+  if (version.split('.').length === 3) {
+    versionToUse = version
+      .split('.')
+      .slice(0, -1)
+      .join('.')
+  }
+  return versionToUse
+}
+
 function nameMapper (name) {
   return function mapName (version) {
     return name + ' ' + version
@@ -768,10 +779,12 @@ var QUERIES = [
   {
     regexp: /^electron\s+([\d.]+)\s*-\s*([\d.]+)$/i,
     select: function (context, from, to) {
-      if (!e2c[from]) {
+      var fromToUse = normalizeElectron(from)
+      var toToUse = normalizeElectron(to)
+      if (!e2c[fromToUse]) {
         throw new BrowserslistError('Unknown version ' + from + ' of electron')
       }
-      if (!e2c[to]) {
+      if (!e2c[toToUse]) {
         throw new BrowserslistError('Unknown version ' + to + ' of electron')
       }
 
@@ -804,8 +817,9 @@ var QUERIES = [
   {
     regexp: /^electron\s*(>=?|<=?)\s*([\d.]+)$/i,
     select: function (context, sign, version) {
+      var versionToUse = normalizeElectron(version)
       return Object.keys(e2c)
-        .filter(generateFilter(sign, version))
+        .filter(generateFilter(sign, versionToUse))
         .map(function (i) {
           return 'chrome ' + e2c[i]
         })
@@ -856,7 +870,8 @@ var QUERIES = [
   {
     regexp: /^electron\s+([\d.]+)$/i,
     select: function (context, version) {
-      var chrome = e2c[version]
+      var versionToUse = normalizeElectron(version)
+      var chrome = e2c[versionToUse]
       if (!chrome) {
         throw new BrowserslistError(
           'Unknown version ' + version + ' of electron')

--- a/test/electron.test.js
+++ b/test/electron.test.js
@@ -4,6 +4,10 @@ it('converts Electron to Chrome', () => {
   expect(browserslist('electron 1.1')).toEqual(['chrome 50'])
 })
 
+it('supports Electron Patch versions to Chrome', () => {
+  expect(browserslist('electron 4.0.4')).toEqual(['chrome 69'])
+})
+
 it('supports case insensitive Electron name', () => {
   expect(browserslist('Electron 1.1')).toEqual(['chrome 50'])
 })
@@ -23,6 +27,10 @@ it('ignores case in Electron ranges', () => {
   expect(browserslist('Electron 0.37-1.0')).toEqual(['chrome 49'])
 })
 
+it('supports patch versions in Electron ranges', () => {
+  expect(browserslist('Electron 0.37.5-1.0.3')).toEqual(['chrome 49'])
+})
+
 it('throws on unknown Electron range version', () => {
   expect(() => {
     browserslist('electron 0.1-1.2')
@@ -39,6 +47,10 @@ it('converts Electron versions to Chrome', () => {
 
 it('ignores case in Electron versions', () => {
   expect(browserslist('Electron < 0.21')).toEqual(['chrome 39'])
+})
+
+it('converts Electron patch versions to Chrome', () => {
+  expect(browserslist('Electron < 0.21.5')).toEqual(['chrome 39'])
 })
 
 it('supports last versions for Electron', () => {


### PR DESCRIPTION
This commit silently changes electron versions with patch, like "4.0.4", to versions without patch ("4.0") so they work with the `electron-to-chromium` version.js file. 

This means people can write their full electron version (or use that automatically) with browserslist.