### PR TITLE
Lock caniuse-lite version for temporary bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": "browserslist/browserslist",
   "dependencies": {
-    "caniuse-lite": "^1.0.30000974",
+    "caniuse-lite": "1.0.30000974",
     "electron-to-chromium": "^1.3.150",
     "node-releases": "^1.1.23"
   },


### PR DESCRIPTION
[caniuse-lite](url) has updated recently to 1.0.30000975 and this issue appeared https://github.com/browserslist/browserslist/issues/382.
Using 1.0.30000974 instead would fix this issue temparary