### PR TITLE
Document string support in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ browsers in `package.json` with `browserslist` key:
 }
 ```
 
+You can also use a string instead of an array, in order to use [`and` combinators](#query-composition).
+
 
 ### `.browserslistrc`
 


### PR DESCRIPTION
This PR adds a simple note about the support of a query defined as a string in package.json. Support for both string and array is only documented in the section related to the JS API. It was not obvious to me that I could use a string in package.json, and I had to dig in the source code starting from the test files, in order to check this. I don't know if this is also true for a configuration defined in .browserslistrc.

I should say that I always used an array/list to define simple and idiomatic queries, and I never had to think about what a comma separated list of browsers queries was actually meaning (conjuction or disjunction). Fortunately, they were providing the expected config.

But if I may (I can open a new issue if needed), allowing the combination of `not` with other combinators is a little bit confusing to me, eg. `last 1 version or not dead` makes me intuitively think that I will get a list of the last browsers version + the list of browers which are not dead. The same is true with `and`. The illustration in the README definitely makes it clear how it actually works, but I was thinking that `last 1 version not dead` might be more clear, I don't know.

Anyway, I hope that those suggestions are usefull.