### PR TITLE
add core-js to the list of Browserslist users

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ front-end tools. It is used in:
 
 * [Autoprefixer]
 * [Babel]
+* [core-js]
 * [postcss-preset-env]
 * [eslint-plugin-compat]
 * [stylelint-no-unsupported-browser-features]
@@ -64,6 +65,7 @@ Browserslist will take queries from tool option,
 [Can I Use]:                                 https://caniuse.com/
 [Babel]:                                     https://github.com/babel/babel/tree/master/packages/babel-preset-env
 [obsolete-webpack-plugin]:                   https://github.com/ElemeFE/obsolete-webpack-plugin
+[core-js]:                                   https://github.com/zloirock/core-js
 
 ## Table of Contents
 


### PR DESCRIPTION
Browserslist config can be used in `core-js-compat` (used by many tools like `@babel/preset-env`) and `core-js-builder`.