### PR TITLE
Look for cached config in each parent folder

### DIFF
--- a/node.js
+++ b/node.js
@@ -239,13 +239,12 @@ module.exports = {
   findConfig: function findConfig (from) {
     from = path.resolve(from)
 
-    var cacheKey = isFile(from) ? path.dirname(from) : from
-    if (cacheKey in configCache) {
-      return configCache[cacheKey]
-    }
-
     var passed = []
     var resolved = eachParent(from, function (dir) {
+      if (dir in configCache) {
+        return configCache[dir]
+      }
+
       passed.push(dir)
 
       var config = path.join(dir, 'browserslist')


### PR DESCRIPTION
Slight improvement for https://github.com/postcss/autoprefixer/issues/1256

Note that this also better matches the updating of cache entries, since eachParent does path.resolve, which the old code didn't do for reading cache