### PR TITLE
Add shareable stats rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ You can specify the browser and Node.js versions by queries (case insensitive):
 * `> 5% in alt-AS`: uses Asia region usage statistics. List of all region codes
   can be found at [`caniuse-lite/data/regions`].
 * `> 5% in my stats`: uses [custom usage data].
+* `> 5% in browserslist-config-mycompany stats`: uses [custom usage data]
+  from `browserslist-config-mycompany/browserslist-stats.json`.
 * `cover 99.5%`: most popular browsers that provide coverage.
 * `cover 99.5% in US`: same as above, with [two-letter country code].
 * `cover 99.5% in my stats`: uses [custom usage data].
@@ -356,6 +358,10 @@ module.exports = [
   'ie 10'
 ]
 ```
+
+You can also include a `browserslist-stats.json` file as part of your shareable
+config at the root and query it using `> 5% in browserslist-config-mycompany stats`.
+It uses the same format as `extends` and the `dangerousExtend` property as above.
 
 
 ## Configuring for Different Environments

--- a/index.js
+++ b/index.js
@@ -686,6 +686,41 @@ var QUERIES = [
     }
   },
   {
+    regexp: /^(>=?|<=?)\s*(\d*\.?\d+)%\s+in\s+(\S+)\s+stats$/,
+    select: function (context, sign, popularity, name) {
+      popularity = parseFloat(popularity)
+      var stats = env.loadStat(context, name, browserslist.data)
+      if (stats) {
+        context.customUsage = { }
+        for (var browser in stats) {
+          fillUsage(context.customUsage, browser, stats[browser])
+        }
+      }
+      if (!context.customUsage) {
+        throw new BrowserslistError('Custom usage statistics was not provided')
+      }
+      var usage = context.customUsage
+      return Object.keys(usage).reduce(function (result, version) {
+        if (sign === '>') {
+          if (usage[version] > popularity) {
+            result.push(version)
+          }
+        } else if (sign === '<') {
+          if (usage[version] < popularity) {
+            result.push(version)
+          }
+        } else if (sign === '<=') {
+          if (usage[version] <= popularity) {
+            result.push(version)
+          }
+        } else if (usage[version] >= popularity) {
+          result.push(version)
+        }
+        return result
+      }, [])
+    }
+  },
+  {
     regexp: /^(>=?|<=?)\s*(\d*\.?\d+)%\s+in\s+((alt-)?\w\w)$/,
     select: function (context, sign, popularity, place) {
       popularity = parseFloat(popularity)

--- a/node.js
+++ b/node.js
@@ -124,6 +124,41 @@ module.exports = {
     return queries
   },
 
+  loadStat: function loadStat (context, name, data) {
+    if (!context.dangerousExtend) checkExtend(name)
+    // eslint-disable-next-line security/detect-non-literal-require
+    var stats = require(
+      require.resolve(
+        path.join(name, 'browserslist-stats.json'),
+        { paths: ['.'] }
+      )
+    )
+
+    if (stats && 'dataByBrowser' in stats) {
+      stats = stats.dataByBrowser
+    }
+
+    if (typeof stats !== 'object') return undefined
+
+    var normalized = { }
+    for (var i in stats) {
+      var versions = Object.keys(stats[i])
+      if (
+        versions.length === 1 &&
+        data[i] &&
+        data[i].versions.length === 1
+      ) {
+        var normal = Object.keys(data[i].versions)[0]
+        normalized[i] = { }
+        normalized[i][normal] = stats[i][versions[0]]
+      } else {
+        normalized[i] = stats[i]
+      }
+    }
+
+    return normalized
+  },
+
   getStat: function getStat (opts, data) {
     var stats
     if (opts.stats) {

--- a/test/shareable-stats.test.js
+++ b/test/shareable-stats.test.js
@@ -1,0 +1,118 @@
+let { ensureDir, writeFile, remove } = require('fs-extra')
+let { join } = require('path')
+
+let browserslist = require('../')
+
+let STATS = join(__dirname, 'fixtures', 'browserslist-stats.json')
+let CUSTOM_STATS = join(__dirname, 'fixtures', 'stats.json')
+
+let mocked = []
+
+async function mock (name, index, stats) {
+  let dir = join(__dirname, '..', 'node_modules', name)
+  mocked.push(dir)
+  await ensureDir(dir)
+  if (index) {
+    let content = 'module.exports = ' + JSON.stringify(index)
+    await writeFile(join(dir, 'index.js'), content)
+  }
+  if (stats) {
+    let statsContent = JSON.stringify(stats)
+    await writeFile(join(dir, 'browserslist-stats.json'), statsContent)
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(mocked.map(dir => remove(dir)))
+  mocked = []
+  delete process.env.BROWSERSLIST_STATS
+})
+
+it('takes stats from shareable config', async () => {
+  await mock(
+    'browserslist-config-test1',
+    undefined,
+    { chrome: { 55: 4, 56: 6 } }
+  )
+  expect(
+    browserslist('> 5% in browserslist-config-test1 stats')
+  ).toEqual(['chrome 56'])
+})
+
+it('takes stats and queries from shareable config', async () => {
+  await mock(
+    'browserslist-config-test2',
+    ['> 1% in browserslist-config-test2 stats'],
+    { ie: { 8: 1, 11: 2 } }
+  )
+  expect(
+    browserslist('extends browserslist-config-test2')
+  ).toEqual(['ie 11'])
+})
+
+it('works with non-prefixed stats with dangerousExtend', async () => {
+  await mock('pkg', undefined, { ie: { 11: 6 } })
+  expect(
+    browserslist(['> 5% in pkg stats'], { dangerousExtend: true })
+  ).toEqual(['ie 11'])
+})
+
+it('handles scoped stats with a dot in the name', async () => {
+  await mock('@example.com/browserslist-config', undefined, { ie: { 11: 6 } })
+  expect(
+    browserslist(['> 5% in @example.com/browserslist-config stats'])
+  ).toEqual(['ie 11'])
+})
+
+it('handles file in scoped stats', async () => {
+  await mock('@scope/browserslist-config/ie', undefined, { ie: { 11: 6 } })
+  expect(
+    browserslist(['> 5% in @scope/browserslist-config/ie stats'])
+  ).toEqual(['ie 11'])
+})
+
+it('handles file-less scoped stats', async () => {
+  await mock('@scope/browserslist-config', undefined, { ie: { 11: 6 } })
+  expect(
+    browserslist(['> 5% in @scope/browserslist-config stats'])
+  ).toEqual(['ie 11'])
+})
+
+it('handles scoped stats', async () => {
+  await mock('@scope/browserslist-config-test', undefined, { ie: { 11: 6 } })
+  expect(
+    browserslist(['> 5% in @scope/browserslist-config-test stats'])
+  ).toEqual(['ie 11'])
+})
+
+it('ignores passed stats', async () => {
+  expect(
+    () =>
+      browserslist('> 5% in browserslist-config-test3 stats', { stats: STATS })
+  ).toThrow(/Cannot resolve module/)
+})
+
+it('ignores environment variable stats', async () => {
+  process.env.BROWSERSLIST_STATS = CUSTOM_STATS
+  expect(
+    () => browserslist('> 5% in browserslist-config-test4 stats')
+  ).toThrow(/Cannot resolve module/)
+})
+
+it('throws when stats does not have browserslist-config- prefix', () => {
+  expect(() => {
+    browserslist(['> 5% in thing-without-prefix stats'])
+  }).toThrow(/needs `browserslist-config-` prefix/)
+})
+
+it('throws when stats has dot in path', () => {
+  expect(() => {
+    browserslist(['> 5% in browserslist-config-package/../something stats'])
+  }).toThrow(/`.` not allowed/)
+})
+
+it('throws when stats has node_modules in path', () => {
+  expect(() => {
+    browserslist(['> 5% in browserslist-config-test/node_modules/a stats'])
+  }).toThrow(/`node_modules` not allowed/)
+})

--- a/test/shareable-stats.test.js
+++ b/test/shareable-stats.test.js
@@ -32,7 +32,7 @@ it('takes stats from shareable config', async () => {
   await mock(
     'browserslist-config-test1',
     undefined,
-    { chrome: { 55: 4, 56: 6 } }
+    { dataByBrowser: { chrome: { 55: 4, 56: 6 } } }
   )
   expect(
     browserslist('> 5% in browserslist-config-test1 stats')
@@ -51,35 +51,47 @@ it('takes stats and queries from shareable config', async () => {
 })
 
 it('works with non-prefixed stats with dangerousExtend', async () => {
-  await mock('pkg', undefined, { ie: { 11: 6 } })
+  await mock('pkg', undefined, { and_chr: { 78: 6 } })
   expect(
     browserslist(['> 5% in pkg stats'], { dangerousExtend: true })
-  ).toEqual(['ie 11'])
+  ).toEqual(['and_chr 78'])
 })
 
 it('handles scoped stats with a dot in the name', async () => {
-  await mock('@example.com/browserslist-config', undefined, { ie: { 11: 6 } })
+  await mock(
+    '@example.com/browserslist-config',
+    undefined,
+    { ie: { 8: 5, 11: 4 } }
+  )
   expect(
-    browserslist(['> 5% in @example.com/browserslist-config stats'])
+    browserslist(['< 5% in @example.com/browserslist-config stats'])
   ).toEqual(['ie 11'])
 })
 
 it('handles file in scoped stats', async () => {
-  await mock('@scope/browserslist-config/ie', undefined, { ie: { 11: 6 } })
+  await mock(
+    '@scope/browserslist-config/ie',
+    undefined,
+    { ie: { 8: 2, 11: 5 } }
+  )
   expect(
-    browserslist(['> 5% in @scope/browserslist-config/ie stats'])
+    browserslist(['>= 5% in @scope/browserslist-config/ie stats'])
   ).toEqual(['ie 11'])
 })
 
 it('handles file-less scoped stats', async () => {
-  await mock('@scope/browserslist-config', undefined, { ie: { 11: 6 } })
+  await mock('@scope/browserslist-config', undefined, { ie: { 8: 6, 11: 5 } })
   expect(
-    browserslist(['> 5% in @scope/browserslist-config stats'])
+    browserslist(['<= 5% in @scope/browserslist-config stats'])
   ).toEqual(['ie 11'])
 })
 
 it('handles scoped stats', async () => {
-  await mock('@scope/browserslist-config-test', undefined, { ie: { 11: 6 } })
+  await mock(
+    '@scope/browserslist-config-test',
+    undefined,
+    { ie: { 8: 2, 11: 6 } }
+  )
   expect(
     browserslist(['> 5% in @scope/browserslist-config-test stats'])
   ).toEqual(['ie 11'])
@@ -115,4 +127,15 @@ it('throws when stats has node_modules in path', () => {
   expect(() => {
     browserslist(['> 5% in browserslist-config-test/node_modules/a stats'])
   }).toThrow(/`node_modules` not allowed/)
+})
+
+it('throw if stats undefined', async () => {
+  await mock(
+    'browserslist-config-undefined',
+    undefined,
+    { dataByBrowser: 'not object' }
+  )
+  expect(
+    () => browserslist(['> 5% in browserslist-config-undefined stats'])
+  ).toThrow(/statistics was not provided/)
 })


### PR DESCRIPTION
Allows for new `> 5% in browserslist-config-mycompany stats` rule.

Works as an amalgamation of `extends` and `in my stats` rules.

fixes: #258 