### PR TITLE
change most prominent example to be more like listed best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ when you add the following to `package.json`:
 
 ```js
   "browserslist": [
-    "last 1 version",
-    "> 0.25%",
-    "maintained node versions",
+    "last 2 versions",
+    "> 0.5%",
+    "Firefox ESR",
     "not dead"
   ]
 ```
@@ -31,9 +31,9 @@ Or in `.browserslistrc` config:
 ```yaml
 # Browsers that we support
 
-last 1 version
-> 0.25%
-maintained node versions
+last 2 versions
+> 0.5%
+Firefox ESR
 not dead
 ```
 
@@ -104,10 +104,6 @@ Browserslist will take queries from tool option,
 
 ## Best Practices
 
-* Select browsers directly (`last 2 Chrome versions`) only if you are making
-  a web app for a kiosk with one browser. There are a lot of browsers
-  on the market. If you are making general web app you should respect
-  browsers diversity.
 * There is a `defaults` query, which gives a reasonable configuration
   for most users:
 
@@ -116,18 +112,18 @@ Browserslist will take queries from tool option,
       "defaults"
     ]
   ```
-
 * If you want to change the default set of browsers we recommend to combine
-  `last 1 version`, `not dead` with `> 0.2%` (or `> 1% in US`,
-  `> 1% in my stats`). `last n versions` adds too many dead browsers
-  and does not add popular old versions. Choosing a percentage above `0.2%`
-  will in the long run make popular browsers even more popular. We might run
-  into a monopoly and stagnation situation, as we had with Internet Explorer 6.
-  Please use this setting with caution.
+  `last 2 versions`, `not dead` with a usage number like `> 0.2%`. This is
+  because `last n versions` on its own does not add popular old versions while
+  only using a percentage above `0.2%` will in the long run make popular browsers
+  even more popular. We might run into a monopoly and stagnation situation, as
+  we had with Internet Explorer 6. Please use this setting with caution.
+* Select browsers directly (`last 2 Chrome versions`) only if you are making
+  a web app for a kiosk with one browser. There are a lot of browsers
+  on the market. If you are making general web app you should respect browsers diversity.
 * Don’t remove browsers just because you don’t know them. Opera Mini has
-  100 million users in Africa and it is more popular in the global market
-  than Microsoft Edge. Chinese QQ Browsers has more market share than Firefox
-  and desktop Safari combined.
+  100 million users in Africa and it is more popular in the global market than Microsoft
+  Edge. Chinese QQ Browsers has more market sharethan Firefox and desktop Safari combined.
 
 
 ## Queries

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ when you add the following to `package.json`:
     "last 2 versions",
     "> 0.5%",
     "Firefox ESR",
+    "maintained node versions",
     "not dead"
   ]
 ```
@@ -33,7 +34,8 @@ Or in `.browserslistrc` config:
 
 last 2 versions
 > 0.5%
-Firefox ESR
+Firefox ESR 
+maintained node versions
 not dead
 ```
 
@@ -123,7 +125,7 @@ Browserslist will take queries from tool option,
   on the market. If you are making general web app you should respect browsers diversity.
 * Don’t remove browsers just because you don’t know them. Opera Mini has
   100 million users in Africa and it is more popular in the global market than Microsoft
-  Edge. Chinese QQ Browsers has more market sharethan Firefox and desktop Safari combined.
+  Edge. Chinese QQ Browsers has more market share than Firefox and desktop Safari combined.
 
 
 ## Queries

--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ when you add the following to `package.json`:
 
 ```js
   "browserslist": [
-    "last 2 versions",
-    "> 0.5%",
-    "Firefox ESR",
+    "defaults",
+    "not IE 11",
     "maintained node versions",
-    "not dead"
   ]
 ```
 
@@ -32,11 +30,9 @@ Or in `.browserslistrc` config:
 ```yaml
 # Browsers that we support
 
-last 2 versions
-> 0.5%
-Firefox ESR 
+defaults
+not IE 11
 maintained node versions
-not dead
 ```
 
 Developers set versions list in queries like `last 2 version`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ when you add the following to `package.json`:
 ```js
   "browserslist": [
     "last 1 version",
-    "> 1%",
+    "> 0.25%",
     "maintained node versions",
     "not dead"
   ]
@@ -32,7 +32,7 @@ Or in `.browserslistrc` config:
 # Browsers that we support
 
 last 1 version
-> 1%
+> 0.25%
 maintained node versions
 not dead
 ```
@@ -173,6 +173,8 @@ in your terminal._
 
 You can specify the browser and Node.js versions by queries (case insensitive):
 
+* `defaults`: Browserslist’s default browsers
+  (`> 0.5%, last 2 versions, Firefox ESR, not dead`).
 * `> 5%`: browsers versions selected by global usage statistics.
   `>=`, `<` and `<=` work too.
 * `> 5% in US`: uses USA usage statistics. It accepts [two-letter country code].
@@ -207,8 +209,6 @@ You can specify the browser and Node.js versions by queries (case insensitive):
   `Samsung 4` and `OperaMobile 12.1`.
 * `last 2 versions`: the last 2 versions for *each* browser.
 * `last 2 Chrome versions`: the last 2 versions of Chrome browser.
-* `defaults`: Browserslist’s default browsers
-  (`> 0.5%, last 2 versions, Firefox ESR, not dead`).
 * `not ie <= 8`: exclude browsers selected by previous queries.
 
 You can add `not ` to any query.


### PR DESCRIPTION
Because the README has a "Best Practices" section that states the following:

> If you want to change the default set of browsers we recommend to combine last 1 version, not dead with > 0.2% (or > 1% in US, > 1% in my stats). last n versions adds too many dead browsers and does not add popular old versions. Choosing a percentage above 0.2% will in the long run make popular browsers even more popular. We might run into a monopoly and stagnation situation, as we had with Internet Explorer 6. Please use this setting with caution.

I figured it make sense to update the most prominent example to be more like that best practice and promote browser diversity in the long run. (I think) A lot of people will just be copying that example in their package.json and think it is the default or recommend setting, so this should help combat that.

I've also moved the `default` setting to the top of the list just to show how absurd a browserlist setting of `> 5%` would be compared to the default.