### PR TITLE
chore: exclude IE_Mob 11 in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ when you add the following to `package.json`:
   "browserslist": [
     "defaults",
     "not IE 11",
+    "not IE_Mob 11",
     "maintained node versions",
   ]
 ```
@@ -32,6 +33,7 @@ Or in `.browserslistrc` config:
 
 defaults
 not IE 11
+not IE_Mob 11
 maintained node versions
 ```
 


### PR DESCRIPTION
The readme example demonstrates how to exclude `IE 11` from the defaults query. However, in this example `IE Mob` (thus, IE Mobile is literally IE Mob) is not excluded. It would cause trouble for those devtools (namely Babel/preset-env) that maps `IE Mob` to `IE` and thus applies IE-related polyfills, which is very confused for the end users since `not IE 11` has been specified. (C.f. https://github.com/babel/babel/issues/10635#issuecomment-549400423)

