### PR TITLE
Fix android queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var e2c = require('electron-to-chromium/versions')
 var BrowserslistError = require('./error')
 var env = require('./node') // Will load browser.js in webpack
 
-var FLOAT_RANGE = /^\d+(\.\d+){0,2}?(-\d+(\.\d+){0,2}?)*$/
 var YEAR = 365.259641 * 24 * 60 * 60 * 1000
+var ANDROID_EVERFIRST_GREEN = 37
 
 var QUERY_OR = 1
 var QUERY_AND = 2
@@ -207,7 +207,7 @@ function byName (name, context) {
 }
 
 function normalizeAndroidVersions (androidVersions, chromeVersions) {
-  var firstEvergreen = 37
+  var firstEvergreen = ANDROID_EVERFIRST_GREEN
   var last = chromeVersions[chromeVersions.length - 1]
   return androidVersions
     .filter(function (version) { return /^(?:[2-4]\.|[34]$)/.test(version) })
@@ -246,7 +246,7 @@ function filterAndroid (list, versions, context) {
     return list
   }
   var released = browserslist.data.android.released
-  var firstEvergreen = 37
+  var firstEvergreen = ANDROID_EVERFIRST_GREEN
   var last = released[released.length - 1]
   var diff = last - firstEvergreen - versions // First Android Evergreen
   if (diff > 0) {
@@ -399,12 +399,11 @@ function browserslist (queries, opts) {
     name1 = name1.split(' ')
     name2 = name2.split(' ')
     if (name1[0] === name2[0]) {
-      // here we assume that caniuse version ranges never overlaps,
-      // so it is safe to use the left of the range
-      // eslint-disable-next-line max-len
-      var version1 = FLOAT_RANGE.test(name1[1]) ? name1[1].split('-')[0] : name1[1]
-      // eslint-disable-next-line max-len
-      var version2 = FLOAT_RANGE.test(name2[1]) ? name2[1].split('-')[0] : name2[1]
+      // assumptions on caniuse data
+      // 1) version ranges never overlaps
+      // 2) if version is not a range, it never contains `-`
+      var version1 = name1[1].split('-')[0]
+      var version2 = name2[1].split('-')[0]
       return compareSemver(version2.split('.'), version1.split('.'))
     } else {
       return compare(name1[0], name2[0])

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var BrowserslistError = require('./error')
 var env = require('./node') // Will load browser.js in webpack
 
 var YEAR = 365.259641 * 24 * 60 * 60 * 1000
-var ANDROID_EVERFIRST_GREEN = 37
+var ANDROID_EVERGREEN_FIRST = 37
 
 var QUERY_OR = 1
 var QUERY_AND = 2
@@ -207,7 +207,7 @@ function byName (name, context) {
 }
 
 function normalizeAndroidVersions (androidVersions, chromeVersions) {
-  var firstEvergreen = ANDROID_EVERFIRST_GREEN
+  var firstEvergreen = ANDROID_EVERGREEN_FIRST
   var last = chromeVersions[chromeVersions.length - 1]
   return androidVersions
     .filter(function (version) { return /^(?:[2-4]\.|[34]$)/.test(version) })
@@ -246,7 +246,7 @@ function filterAndroid (list, versions, context) {
     return list
   }
   var released = browserslist.data.android.released
-  var firstEvergreen = ANDROID_EVERFIRST_GREEN
+  var firstEvergreen = ANDROID_EVERGREEN_FIRST
   var last = released[released.length - 1]
   var diff = last - firstEvergreen - versions // First Android Evergreen
   if (diff > 0) {

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ function normalizeAndroidVersions (androidVersions, chromeVersions) {
   var firstEvergreen = 37
   var last = chromeVersions[chromeVersions.length - 1]
   return androidVersions
-    .filter(function (version) { return /^[2-4]\.|3|4/.test(version) })
+    .filter(function (version) { return /^(?:[2-4]\.|[34]$)/.test(version) })
     .concat(chromeVersions.slice(firstEvergreen - last - 1))
 }
 

--- a/test/direct.test.js
+++ b/test/direct.test.js
@@ -63,6 +63,8 @@ it('supports Can I Use missing mobile versions', () => {
     .toEqual(['and_chr 53', 'and_chr 52'])
   expect(browserslist('and_chr 52-53', opts))
     .toEqual(['and_chr 53', 'and_chr 52'])
+  expect(browserslist('android 4.4-38', opts))
+    .toEqual(['android 38', 'android 37', 'android 4.4.3-4.4.4', 'android 4.4'])
 })
 
 it('missing mobile versions are not aliased by default', () => {

--- a/test/major.test.js
+++ b/test/major.test.js
@@ -29,7 +29,7 @@ beforeEach(() => {
     },
     android: {
       name: 'android',
-      released: ['4.4', '4.4.3-4.4.4', '67']
+      released: ['4.4', '4.4.3-4.4.4', '39']
     }
   }
 })
@@ -40,7 +40,7 @@ afterEach(() => {
 
 it('selects versions of each browser', () => {
   expect(browserslist('last 2 major versions')).toEqual([
-    'android 67',
+    'android 39',
     'bb 10',
     'chrome 39',
     'chrome 38',
@@ -54,13 +54,13 @@ it('selects versions of each browser', () => {
 
 it('supports pluralization', () => {
   expect(browserslist('last 1 major version')).toEqual([
-    'android 67', 'bb 10', 'chrome 39', 'edge 12', 'ie 11'
+    'android 39', 'bb 10', 'chrome 39', 'edge 12', 'ie 11'
   ])
 })
 
 it('is case insensitive', () => {
   expect(browserslist('Last 01 MaJoR Version')).toEqual([
-    'android 67', 'bb 10', 'chrome 39', 'edge 12', 'ie 11'
+    'android 39', 'bb 10', 'chrome 39', 'edge 12', 'ie 11'
   ])
 })
 
@@ -75,6 +75,6 @@ it('selects versions of a single browser', () => {
     'chrome 39', 'chrome 38', 'chrome 37'
   ])
   expect(browserslist('last 2 android major versions')).toEqual([
-    'android 67'
+    'android 39'
   ])
 })

--- a/test/major.test.js
+++ b/test/major.test.js
@@ -29,7 +29,8 @@ beforeEach(() => {
     },
     android: {
       name: 'android',
-      released: ['4.4', '4.4.3-4.4.4', '39']
+      released: ['4.4', '4.4.3-4.4.4', '39'],
+      versions: ['4.4', '4.4.3-4.4.4', '39']
     }
   }
 })
@@ -76,5 +77,12 @@ it('selects versions of a single browser', () => {
   ])
   expect(browserslist('last 2 android major versions')).toEqual([
     'android 39'
+  ])
+})
+
+it('supports Can I Use missing mobile versions', () => {
+  let opts = { mobileToDesktop: true }
+  expect(browserslist('last 2 android major versions', opts)).toEqual([
+    'android 39', 'android 38'
   ])
 })

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -55,6 +55,9 @@ it('supports comparison operator', () => {
     'node 4.1.0',
     'node 4.0.0',
 
+    'node 0.12.0',
+    'node 0.11.0',
+    'node 0.10.0',
     'node 0.9.0',
     'node 0.8.0',
     'node 0.7.0',
@@ -62,10 +65,7 @@ it('supports comparison operator', () => {
     'node 0.5.0',
     'node 0.4.0',
     'node 0.3.0',
-    'node 0.2.0',
-    'node 0.12.0',
-    'node 0.11.0',
-    'node 0.10.0'
+    'node 0.2.0'
   ])
 
   expect(browserslist('node < 5')).toEqual([
@@ -80,6 +80,9 @@ it('supports comparison operator', () => {
     'node 4.1.0',
     'node 4.0.0',
 
+    'node 0.12.0',
+    'node 0.11.0',
+    'node 0.10.0',
     'node 0.9.0',
     'node 0.8.0',
     'node 0.7.0',
@@ -87,10 +90,7 @@ it('supports comparison operator', () => {
     'node 0.5.0',
     'node 0.4.0',
     'node 0.3.0',
-    'node 0.2.0',
-    'node 0.12.0',
-    'node 0.11.0',
-    'node 0.10.0'
+    'node 0.2.0'
   ])
 
   expect(browserslist('Node <= 5')).toHaveLength(22)

--- a/test/range.test.js
+++ b/test/range.test.js
@@ -8,6 +8,12 @@ beforeEach(() => {
       name: 'ie',
       released: ['8', '9', '10', '11'],
       versions: ['8', '9', '10', '11']
+    },
+    android: {
+      name: 'android',
+      released: ['4.2-4.3', '4.4',
+        '4.4.3-4.4.4', '37'],
+      versions: ['4.2-4.3', '4.4', '4.4.3-4.4.4', '37']
     }
   }
 })
@@ -22,6 +28,13 @@ it('selects a range of browsers', () => {
 
 it('selects versions with query out of range', () => {
   expect(browserslist('ie 1-12')).toEqual(['ie 11', 'ie 10', 'ie 9', 'ie 8'])
+})
+
+it('selects a range of android browsers', () => {
+  expect(browserslist('android 4.3-37'))
+    .toEqual([
+      'android 37', 'android 4.4.3-4.4.4', 'android 4.4', 'android 4.2-4.3'
+    ])
 })
 
 it('raises on an unknown browser', () => {

--- a/test/range.test.js
+++ b/test/range.test.js
@@ -11,8 +11,7 @@ beforeEach(() => {
     },
     android: {
       name: 'android',
-      released: ['4.2-4.3', '4.4',
-        '4.4.3-4.4.4', '37'],
+      released: ['4.2-4.3', '4.4', '4.4.3-4.4.4', '37'],
       versions: ['4.2-4.3', '4.4', '4.4.3-4.4.4', '37']
     }
   }
@@ -31,10 +30,9 @@ it('selects versions with query out of range', () => {
 })
 
 it('selects a range of android browsers', () => {
-  expect(browserslist('android 4.3-37'))
-    .toEqual([
-      'android 37', 'android 4.4.3-4.4.4', 'android 4.4', 'android 4.2-4.3'
-    ])
+  expect(browserslist('android 4.3-37')).toEqual([
+    'android 37', 'android 4.4.3-4.4.4', 'android 4.4', 'android 4.2-4.3'
+  ])
 })
 
 it('raises on an unknown browser', () => {


### PR DESCRIPTION
I recommend to review this PR by commits.

The first commits merge chrome >= 37 data to android under the `mobileToDesktop` flag

The second commits fixed result sorting issues occured when I wrote test for the first commit.

I propose in In the next major release we should set the defaults of `opts.mobileToDesktop` to be `true` so that the returned mobile browsers are complete. People can disable this feature if they find things are not going well.