### PR TITLE
Fix typo releaseData -> releaseDate

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ function cloneData (data) {
     name: data.name,
     versions: data.versions,
     released: data.released,
-    releaseData: data.releaseDate
+    releaseDate: data.releaseDate
   }
 }
 


### PR DESCRIPTION
I think a small typo was merged yesterday

It causes errors like:
> TypeError: [BABEL] /Users/antoine/Code/clapp-webapp/src/index.jsx: Cannot convert undefined or null to object (While processing: "/Users/antoine/Code/clapp-webapp/node_modules/@babel/preset-env/lib/index.js")
    at Function.keys (<anonymous>)
    at /Users/antoine/Code/clapp-webapp/node_modules/browserslist/index.js:175:27
[...]