### PR TITLE
fix: defaults query should respect options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1013,8 +1013,8 @@ var QUERIES = [
   },
   {
     regexp: /^defaults$/i,
-    select: function () {
-      return browserslist(browserslist.defaults)
+    select: function (context) {
+      return resolve(browserslist.defaults, context)
     }
   },
   {

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -9,3 +9,8 @@ it('selects defaults by keywords', () => {
 it('selects defaults case insensitive', () => {
   expect(browserslist('Defaults')).toEqual(browserslist(browserslist.defaults))
 })
+
+it('should respect options', () => {
+  expect(browserslist('defaults', { mobileToDesktop: true }))
+    .toEqual(browserslist(browserslist.defaults, { mobileToDesktop: true }))
+})


### PR DESCRIPTION
It was found when I am fixing babel CI error. 😄