### PR TITLE
Revert "Fix released browsers versions", closes #439

### DIFF
--- a/index.js
+++ b/index.js
@@ -1051,7 +1051,7 @@ var QUERIES = [
     browserslist.data[name] = {
       name: name,
       versions: normalize(agents[name].versions),
-      released: normalize(agents[name].versions.slice(0, -2)),
+      released: normalize(agents[name].versions.slice(0, -3)),
       releaseDate: agents[name].release_date
     }
     fillUsage(browserslist.usage.global, name, browser.usage_global)


### PR DESCRIPTION
This reverts commit 1e61852c55a31c83520392a61e3d2ad7d6cd0e8c.
The commit introduces drifted latest browsers versions instead, after the `caniuse-db` updated after it.
closes #439 