### PR TITLE
fix last N major versions with non-sequential version numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,11 @@ function getMajor (version) {
 
 function getMajorVersions (released, number) {
   if (released.length === 0) return []
-  var minimum = getMajor(released[released.length - 1]) - parseInt(number) + 1
+  var majorVersions = uniq(released.map(getMajor))
+  var minimum = majorVersions[majorVersions.length - number]
+  if (!minimum) {
+    return released
+  }
   var selected = []
   for (var i = released.length - 1; i >= 0; i--) {
     if (minimum > getMajor(released[i])) break

--- a/test/major.test.js
+++ b/test/major.test.js
@@ -43,6 +43,7 @@ it('selects versions of each browser', () => {
   expect(browserslist('last 2 major versions')).toEqual([
     'android 39',
     'bb 10',
+    'bb 8',
     'chrome 39',
     'chrome 38',
     'edge 12',
@@ -77,6 +78,18 @@ it('selects versions of a single browser', () => {
   ])
   expect(browserslist('last 2 android major versions')).toEqual([
     'android 39'
+  ])
+})
+
+it('supports non-sequential version numbers', () => {
+  expect(browserslist('last 2 bb major versions')).toEqual([
+    'bb 10', 'bb 8'
+  ])
+})
+
+it('supports more versions than have been released', () => {
+  expect(browserslist('last 3 bb major versions')).toEqual([
+    'bb 10', 'bb 8'
   ])
 })
 


### PR DESCRIPTION
Fixes #447.

This changes the way the minimum major version is calculated.
Previously it was calculated by subtracting the desired number of versions from the maximum version number which does not yield the desired outcome when a browser has non-sequential version numbers (e.g. edge 17, 18, 79, 80).

The change involves finding the released major versions and taking the last N of those rather than relying on simple subtraction and an assumption of sequential version numbers.