### PR TITLE
docs(readme): add adobe-analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,14 @@ Browserslist will take queries from tool option,
   by user agent string to match Browserslist.
 * [`browserslist-browserstack`] runs BrowserStack tests for all browsers
   in Browserslist config.
+* [`browserslist-adobe-analytics`] use Adobe Analytics data to target browsers.
 * [`caniuse-api`] returns browsers which support some specific feature.
 * Run `npx browserslist` in your project directory to see project’s
   target browsers. This CLI tool is built-in and available in any project
   with Autoprefixer.
 
 [`browserslist-useragent-regexp`]: https://github.com/browserslist/browserslist-useragent-regexp
+[`browserslist-adobe-analytics`]:  https://github.com/xeroxinteractive/browserslist-adobe-analytics
 [`browserslist-useragent-ruby`]:   https://github.com/browserslist/browserslist-useragent-ruby
 [`browserslist-browserstack`]:     https://github.com/xeroxinteractive/browserslist-browserstack
 [`browserslist-ga-export`]:        https://github.com/browserslist/browserslist-ga-export


### PR DESCRIPTION
browserslist-adove-analytics is a tool I created that allows you to automate the generation of `browserslist_stats.json` files from Adobe Analytics data either via a Node API or the CLI. Thought it would be useful to include here for anyone that uses Adobe Analytics and wants to use its data similarly to browserslist-ga and browserslist-ga-export.