### PR TITLE
Workaround incorrect caniuse regional data

### DIFF
--- a/index.js
+++ b/index.js
@@ -588,7 +588,7 @@ browserslist.coverage = function (browsers, stats) {
     } else {
       stats = stats.toUpperCase()
     }
-    env.loadCountry(browserslist.usage, stats)
+    env.loadCountry(browserslist.usage, stats, browserslist.data)
     data = browserslist.usage[stats]
   } else {
     if ('dataByBrowser' in stats) {
@@ -823,7 +823,7 @@ var QUERIES = [
       } else {
         place = place.toLowerCase()
       }
-      env.loadCountry(browserslist.usage, place)
+      env.loadCountry(browserslist.usage, place, browserslist.data)
       var usage = browserslist.usage[place]
       return Object.keys(usage).reduce(function (result, version) {
         if (sign === '>') {
@@ -866,7 +866,7 @@ var QUERIES = [
           } else {
             place = place.toLowerCase()
           }
-          env.loadCountry(browserslist.usage, place)
+          env.loadCountry(browserslist.usage, place, browserslist.data)
           usage = browserslist.usage[place]
         }
       }

--- a/node.js
+++ b/node.js
@@ -137,6 +137,22 @@ function normalizeStats (data, stats) {
   return normalized
 }
 
+function normalizeUsageData (usageData, data) {
+  for (var browser in usageData) {
+    var browserUsage = usageData[browser]
+    // eslint-disable-next-line max-len
+    // https://github.com/browserslist/browserslist/issues/431#issuecomment-565230615
+    // caniuse-db returns { 0: "percentage" } for `and_*` regional stats
+    if ('0' in browserUsage) {
+      var versions = data[browser].versions
+      if (versions.length > 0) {
+        browserUsage[versions[versions.length - 1]] = browserUsage[0]
+        delete browserUsage[0]
+      }
+    }
+  }
+}
+
 module.exports = {
   loadQueries: function loadQueries (context, name) {
     if (!context.dangerousExtend) checkExtend(name)
@@ -201,16 +217,17 @@ module.exports = {
     }
   },
 
-  loadCountry: function loadCountry (usage, country) {
+  loadCountry: function loadCountry (usage, country, data) {
     var code = country.replace(/[^\w-]/g, '')
     if (!usage[code]) {
       // eslint-disable-next-line security/detect-non-literal-require
       var compressed = require('caniuse-lite/data/regions/' + code + '.js')
-      var data = region(compressed)
+      var usageData = region(compressed)
+      normalizeUsageData(usageData, data)
       usage[country] = { }
-      for (var i in data) {
-        for (var j in data[i]) {
-          usage[country][i + ' ' + j] = data[i][j]
+      for (var i in usageData) {
+        for (var j in usageData[i]) {
+          usage[country][i + ' ' + j] = usageData[i][j]
         }
       }
     }

--- a/node.js
+++ b/node.js
@@ -145,10 +145,8 @@ function normalizeUsageData (usageData, data) {
     // caniuse-db returns { 0: "percentage" } for `and_*` regional stats
     if ('0' in browserUsage) {
       var versions = data[browser].versions
-      if (versions.length > 0) {
-        browserUsage[versions[versions.length - 1]] = browserUsage[0]
-        delete browserUsage[0]
-      }
+      browserUsage[versions[versions.length - 1]] = browserUsage[0]
+      delete browserUsage[0]
     }
   }
 }

--- a/test/country.test.js
+++ b/test/country.test.js
@@ -9,7 +9,13 @@ beforeEach(() => {
       'ie 9': 5,
       'ie 10': 10.1,
       'ie 11': 75
+    },
+    XX: {
+      'and_chr 0': 100
     }
+  }
+  browserslist.data.and_chr = {
+    versions: ['80']
   }
 })
 
@@ -57,4 +63,8 @@ it('loads continents from Can I Use', () => {
 
 it('allows omission of the space between the > and the percentage', () => {
   expect(browserslist('>10% in US').length > 0).toBe(true)
+})
+
+it('normalize incorrect caniuse versions for and_*', () => {
+  expect(browserslist('> 50% in XX')).toEqual(['and_chr 80'])
 })


### PR DESCRIPTION
In this PR we normalize the usage data
```js
{ and_chr: {0: 30.6943} }
```
returned from the `caniuse-db` to
```js
{ and_chr: {80: 30.6943} }
```
where `80` is the latest version in `browserslists.data`. By doing so the regional data should not return `chrome 4` for the invalid `and_chr 0` query.

Fixes #431 