### PR TITLE
Docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ not IE_Mob 11
 maintained node versions
 ```
 
-Developers set their version lists using queries like `last 2 version`
+Developers set their version lists using queries like `last 2 versions`
 to be free from updating versions manually.
 Browserslist will use [`caniuse-lite`] with [Can I Use] data for this queries.
 


### PR DESCRIPTION
This fixes a very minor typo in the README, where the singular instead of the plural was used to express a browser query.
