### PR TITLE
feat: add mobileToDesktop option to CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,7 @@ var USAGE = 'Usage:\n' +
             '  npx browserslist --coverage=US,RU,global "QUERIES"\n' +
             '  npx browserslist --env="environment name defined in config"\n' +
             '  npx browserslist --stats="path/to/browserlist/stats/file"\n' +
+            '  npx browserslist --mobileToDesktop\n' +
             '  npx browserslist --update-db'
 
 function isArg (arg) {
@@ -72,6 +73,8 @@ if (isArg('--help') || isArg('-h')) {
       }
     } else if (name === '--json') {
       mode = 'json'
+    } else if (name === '--mobileToDesktop' || name === '-m') {
+      opts.mobileToDesktop = true
     } else {
       error('Unknown arguments ' + args[i] + '.\n\n' + USAGE)
     }


### PR DESCRIPTION
This PR adds the `--mobileToDesktop` or `-m` option to the `cli.js`. 

This was primarily added to test this functionality without using the JS API. A real-world use-case I had recently was wanting to easily and quickly test browserslist output as per the issue at https://github.com/browserslist/browserslist/issues/431

I'm happy to make any changes you feel are necessary to get this merged.