### PR TITLE
✨ shareable: env support

### DIFF
--- a/index.js
+++ b/index.js
@@ -424,7 +424,8 @@ function browserslist (queries, opts) {
   var context = {
     ignoreUnknownVersions: opts.ignoreUnknownVersions,
     dangerousExtend: opts.dangerousExtend,
-    mobileToDesktop: opts.mobileToDesktop
+    mobileToDesktop: opts.mobileToDesktop,
+    env: opts.env
   }
 
   env.oldDataWarning(browserslist.data)

--- a/node.js
+++ b/node.js
@@ -156,12 +156,17 @@ module.exports = {
     if (!context.dangerousExtend) checkExtend(name)
     // eslint-disable-next-line security/detect-non-literal-require
     var queries = require(require.resolve(name, { paths: ['.'] }))
-    if (queries && queries.constructor === Object) {
-      if (!queries.defaults) queries.defaults = []
-      return pickEnv(queries, context)
+    if (!queries) {
+      throw new BrowserslistError(
+        '`' + name + '` config doesn\'t export a configuration'
+      )
     }
     if (Array.isArray(queries)) {
       return queries
+    }
+    if (typeof queries === 'object') {
+      if (!queries.defaults) queries.defaults = []
+      return pickEnv(queries, context, name)
     }
     throw new BrowserslistError(
       '`' + name + '` config exports not an array of queries' +

--- a/node.js
+++ b/node.js
@@ -156,12 +156,17 @@ module.exports = {
     if (!context.dangerousExtend) checkExtend(name)
     // eslint-disable-next-line security/detect-non-literal-require
     var queries = require(require.resolve(name, { paths: ['.'] }))
-    if (!Array.isArray(queries)) {
-      throw new BrowserslistError(
-        '`' + name + '` config exports not an array of queries'
-      )
+    if (queries && queries.constructor === Object) {
+      if (!queries.defaults) queries.defaults = []
+      return pickEnv(queries, context)
     }
-    return queries
+    if (Array.isArray(queries)) {
+      return queries
+    }
+    throw new BrowserslistError(
+      '`' + name + '` config exports not an array of queries' +
+      ' or an object of envs'
+    )
   },
 
   loadStat: function loadStat (context, name, data) {

--- a/test/extends.test.js
+++ b/test/extends.test.js
@@ -103,6 +103,14 @@ it('throws when extends package has node_modules in path', () => {
   }).toThrow(/`node_modules` not allowed/)
 })
 
+it('works with shareable config doesn\'t contains defaults env', async () => {
+  await mock('browserslist-config-with-env-a', {
+    someEnv: ['ie 10']
+  })
+  let result = browserslist(['extends browserslist-config-with-env-a'])
+  expect(result).toEqual([])
+})
+
 it('works with shareable config contains env', async () => {
   process.env.NODE_ENV = 'test'
   await mock('browserslist-config-with-env', {

--- a/test/extends.test.js
+++ b/test/extends.test.js
@@ -127,3 +127,11 @@ it('works with shareable config contains defaults env', async () => {
   let result = browserslist(['extends browserslist-config-with-defaults'])
   expect(result).toEqual(['ie 10'])
 })
+
+it('throws when external package resolve to nullable',
+  async () => {
+    await mock('browserslist-config-null', null)
+    expect(() => {
+      browserslist(['extends browserslist-config-null'])
+    }).toThrow(/onfig doesn't export a configuration/)
+  })

--- a/test/extends.test.js
+++ b/test/extends.test.js
@@ -112,18 +112,18 @@ it('works with shareable config doesn\'t contains defaults env', async () => {
 })
 
 it('works with shareable config contains env', async () => {
-  process.env.NODE_ENV = 'test'
-  await mock('browserslist-config-with-env', {
-    test: ['ie 10']
+  process.env.NODE_ENV = 'someEnv'
+  await mock('browserslist-config-with-env-b', {
+    someEnv: ['ie 10']
   })
-  let result = browserslist(['extends browserslist-config-with-env'])
+  let result = browserslist(['extends browserslist-config-with-env-b'])
   expect(result).toEqual(['ie 10'])
 })
 
 it('works with shareable config contains defaults env', async () => {
-  await mock('browserslist-config-with-env', {
+  await mock('browserslist-config-with-defaults', {
     defaults: ['ie 10']
   })
-  let result = browserslist(['extends browserslist-config-with-env'])
+  let result = browserslist(['extends browserslist-config-with-defaults'])
   expect(result).toEqual(['ie 10'])
 })

--- a/test/extends.test.js
+++ b/test/extends.test.js
@@ -77,12 +77,13 @@ it('handles relative queries with local overrides', async () => {
   expect(result).toEqual(['ie 10'])
 })
 
-it('throws when external package does not resolve to an array', async () => {
-  await mock('browserslist-config-wrong', { not: 'an array' })
-  expect(() => {
-    browserslist(['extends browserslist-config-wrong'])
-  }).toThrow(/not an array/)
-})
+it('throws when external package does not resolve to an array or an object',
+  async () => {
+    await mock('browserslist-config-wrong', 'some string')
+    expect(() => {
+      browserslist(['extends browserslist-config-wrong'])
+    }).toThrow(/not an array of queries or an object/)
+  })
 
 it('throws when package does not have browserslist-config- prefix', () => {
   expect(() => {
@@ -100,4 +101,21 @@ it('throws when extends package has node_modules in path', () => {
   expect(() => {
     browserslist(['extends browserslist-config-test/node_modules/a'])
   }).toThrow(/`node_modules` not allowed/)
+})
+
+it('works with shareable config contains env', async () => {
+  process.env.NODE_ENV = 'test'
+  await mock('browserslist-config-with-env', {
+    test: ['ie 10']
+  })
+  let result = browserslist(['extends browserslist-config-with-env'])
+  expect(result).toEqual(['ie 10'])
+})
+
+it('works with shareable config contains defaults env', async () => {
+  await mock('browserslist-config-with-env', {
+    defaults: ['ie 10']
+  })
+  let result = browserslist(['extends browserslist-config-with-env'])
+  expect(result).toEqual(['ie 10'])
 })


### PR DESCRIPTION
Resolves: #300

Example:
```js
module.exports = {
    defaults: ['> 1%],
    test: ['current node']
}
``` 

It's not breaking changes according to code.
But it's breaking changes according to tests, which make sense that I have to edit test case for non-array error.