### PR TITLE
Add keywords: safe, unsafe, balanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Browserslist will take queries from tool option,
     ]
   ```
 
+* If you're targeting modern browsers, we recommend using `balanced`. This set
+  cuts the bloat by selecting only browsers that still receive security updates.
+  It requires 75% less poly-filling than the `default` set while providing a
+  good global coverage (> 85%).
+  [(analysis)](https://github.com/browserslist/browserslist/issues/435#issuecomment-575407090)
 * If you want to change the default set of browsers, we recommend combining
   `last 2 versions`, `not dead` with a usage number like `> 0.2%`. This is
   because `last n versions` on its own does not add popular old versions, while
@@ -155,7 +160,7 @@ from one of these sources:
 4. `BROWSERSLIST` environment variable.
 5. If the above methods did not produce a valid result
    Browserslist will use defaults:
-   `> 0.5%, last 2 versions, Firefox ESR, not dead`.
+   `> 0.5%, last 2 versions, safe, not dead`.
 
 
 ### Query Composition
@@ -187,7 +192,9 @@ in your terminal._
 You can specify the browser and Node.js versions by queries (case insensitive):
 
 * `defaults`: Browserslist’s default browsers
-  (`> 0.5%, last 2 versions, Firefox ESR, not dead`).
+  (`> 0.5%, last 2 versions, safe, not dead`).
+* `balanced`: target modern (updated) browsers (`last 2 versions, safe, not
+  unsafe, not < 0.1%`).
 * `> 5%`: browsers versions selected by global usage statistics.
   `>=`, `<` and `<=` work too.
 * `> 5% in US`: uses USA usage statistics. It accepts [two-letter country code].
@@ -222,6 +229,10 @@ You can specify the browser and Node.js versions by queries (case insensitive):
 * `dead`: browsers without official support or updates for 24 months.
   Right now it is `IE 10`, `IE_Mob 10`, `BlackBerry 10`, `BlackBerry 7`,
   `Samsung 4` and `OperaMobile 12.1`.
+* `safe`: browsers that are not part of `last 2 versions` anymore but that are
+  still receiving security patches.
+* `unsafe`: browsers that are still part of `last 2 versions` but that are not
+  receiving security patches anymore.
 * `last 2 versions`: the last 2 versions for *each* browser.
 * `last 2 Chrome versions`: the last 2 versions of Chrome browser.
 * `not ie <= 8`: exclude browsers selected by previous queries.

--- a/index.js
+++ b/index.js
@@ -514,7 +514,7 @@ browserslist.usage = {
 browserslist.defaults = [
   '> 0.5%',
   'last 2 versions',
-  'Firefox ESR',
+  'safe',
   'not dead'
 ]
 
@@ -1102,6 +1102,18 @@ var QUERIES = [
     }
   },
   {
+    regexp: /^balanced$/i,
+    select: function (context) {
+      var balanced = [
+        'last 2 versions',
+        'safe',
+        'not unsafe',
+        'not < 0.1%'
+      ]
+      return resolve(balanced, context)
+    }
+  },
+  {
     regexp: /^dead$/i,
     select: function (context) {
       var dead = [
@@ -1112,6 +1124,30 @@ var QUERIES = [
         'samsung 4'
       ]
       return resolve(dead, context)
+    }
+  },
+  {
+    // Not in `last 2 versions` but still receive _security_ updates.
+    regexp: /^safe$/i,
+    select: function (context) {
+      var safe = [
+        'firefox esr', // Long-Term-Support
+        'ios_saf 12', // Still active
+        'edge 18' // Still active
+      ]
+      return resolve(safe, context)
+    }
+  },
+  {
+    // In `last 2 versions` but doesn't receive _security_ updates.
+    regexp: /^unsafe$/i,
+    select: function (context) {
+      var unsafe = [
+        'ie 11', // No more security fixes
+        'ie_mob 11', // Almost dead
+        'op_mob 46' // Outdated, now based on Chrome
+      ]
+      return resolve(unsafe, context)
     }
   },
   {

--- a/test/balanced.test.js
+++ b/test/balanced.test.js
@@ -1,0 +1,9 @@
+let browserslist = require('../')
+
+it('selects balanced browsers by keywords', () => {
+  expect(browserslist('balanced')).toContain('firefox esr')
+})
+
+it('selects balanced browsers case insensitive', () => {
+  expect(browserslist('Balanced')).toEqual(browserslist('balanced'))
+})

--- a/test/safe.test.js
+++ b/test/safe.test.js
@@ -1,0 +1,9 @@
+let browserslist = require('../')
+
+it('selects safe browsers by keywords', () => {
+  expect(browserslist('safe')).toContain('firefox 68')
+})
+
+it('selects safe browsers case insensitive', () => {
+  expect(browserslist('Safe')).toEqual(browserslist('safe'))
+})

--- a/test/unsafe.test.js
+++ b/test/unsafe.test.js
@@ -1,0 +1,9 @@
+let browserslist = require('../')
+
+it('selects unsafe browsers by keywords', () => {
+  expect(browserslist('unsafe')).toContain('ie 11')
+})
+
+it('selects unsafe browsers case insensitive', () => {
+  expect(browserslist('Unsafe')).toEqual(browserslist('unsafe'))
+})


### PR DESCRIPTION
This PR implements the proposal that solves #435 by implementing new keywords: `safe`, `unsafe` as well as the browsers set `balanced` that greatly reduce poly-filling but excluding unsafe browsers while retaining a global coverage > 85%. ([analysis](https://github.com/browserslist/browserslist/issues/435#issuecomment-575407090))