### PR TITLE
Remove trailing comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ front-end tools. It is used in:
 All tools will find target browsers automatically,
 when you add the following to `package.json`:
 
-```js
+```json
   "browserslist": [
     "defaults",
     "not IE 11",
     "not IE_Mob 11",
-    "maintained node versions",
+    "maintained node versions"
   ]
 ```
 


### PR DESCRIPTION
The readme says:
> All tools will find target browsers automatically,
> when you add the following to `package.json`:
> 
> ```js
>   "browserslist": [
>     "defaults",
>     "not IE 11",
>     "not IE_Mob 11",
>     "maintained node versions",
>   ]
> ```

But the code is not valid JSON since there is a comma after `"maintained node versions"`. This PR removes the comma