### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ You can add `not ` to any query.
 
 ### Debug
 
-Run `npx browserslist` in project directory to see what browsers was selected
+Run `npx browserslist defaults` in project directory to see what browsers was selected
 by your queries.
 
 ```sh


### PR DESCRIPTION
`npx browserslist` resut is:

```bash
Share browsers list between different front-end tools, like Autoprefixer, Stylelint and babel-env-preset

Usage:
  browserslist "QUERIES"
  browserslist --coverage "QUERIES"
  browserslist --coverage=US "QUERIES"
  browserslist --config=browserslist "path/to/browserlist/file"
  browserslist --env="environment name defined in config"
  browserslist --stats="path/to/browserlist/stats/file"
```

So, update docs `npx browserslist` to `npx browserslist defaults`