### PR TITLE
chore: simplify `package.json` searcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "caniuse-lite": "^1.0.30001043",
     "electron-to-chromium": "^1.3.413",
-    "node-releases": "^1.1.53",
-    "pkg-up": "^2.0.0"
+    "escalade": "^1.0.0",
+    "node-releases": "^1.1.53"
   },
   "bin": "./cli.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "caniuse-lite": "^1.0.30001043",
     "electron-to-chromium": "^1.3.413",
-    "escalade": "^2.0.0",
+    "escalade": "^3.0.0",
     "node-releases": "^1.1.53"
   },
   "bin": "./cli.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "caniuse-lite": "^1.0.30001043",
     "electron-to-chromium": "^1.3.413",
-    "escalade": "^1.0.0",
+    "escalade": "^2.0.0",
     "node-releases": "^1.1.53"
   },
   "bin": "./cli.js",

--- a/test/update-db.test.js
+++ b/test/update-db.test.js
@@ -1,7 +1,7 @@
 let { remove, copy, readFile, ensureDir } = require('fs-extra')
 let { execSync } = require('child_process')
 let { nanoid } = require('nanoid/non-secure')
-let { homedir } = require('os')
+let { tmpdir } = require('os')
 let { join } = require('path')
 
 let updateDd = require('../update-db')
@@ -17,7 +17,7 @@ afterEach(async () => {
 })
 
 async function chdir (fixture, ...files) {
-  testdir = join(homedir(), `browserslist-test-${ fixture }-${ nanoid() }`)
+  testdir = join(tmpdir(), `browserslist-${ fixture }-${ nanoid() }`)
   await ensureDir(testdir)
 
   let from = join(__dirname, 'fixtures', fixture)

--- a/test/update-db.test.js
+++ b/test/update-db.test.js
@@ -1,7 +1,7 @@
 let { remove, copy, readFile, ensureDir } = require('fs-extra')
 let { execSync } = require('child_process')
 let { nanoid } = require('nanoid/non-secure')
-let { tmpdir, homedir } = require('os')
+let { homedir } = require('os')
 let { join } = require('path')
 
 let updateDd = require('../update-db')
@@ -17,7 +17,7 @@ afterEach(async () => {
 })
 
 async function chdir (fixture, ...files) {
-  testdir = join(homedir(), tmpdir(), `browserslist-${ fixture }-${ nanoid() }`)
+  testdir = join(homedir(), `browserslist-test-${ fixture }-${ nanoid() }`)
   await ensureDir(testdir)
 
   let from = join(__dirname, 'fixtures', fixture)

--- a/test/update-db.test.js
+++ b/test/update-db.test.js
@@ -1,7 +1,7 @@
 let { remove, copy, readFile, ensureDir } = require('fs-extra')
 let { execSync } = require('child_process')
 let { nanoid } = require('nanoid/non-secure')
-let { tmpdir } = require('os')
+let { tmpdir, homedir } = require('os')
 let { join } = require('path')
 
 let updateDd = require('../update-db')
@@ -17,7 +17,7 @@ afterEach(async () => {
 })
 
 async function chdir (fixture, ...files) {
-  testdir = join(tmpdir(), `browserslist-${ fixture }-${ nanoid() }`)
+  testdir = join(homedir(), tmpdir(), `browserslist-${ fixture }-${ nanoid() }`)
   await ensureDir(testdir)
 
   let from = join(__dirname, 'fixtures', fixture)

--- a/update-db.js
+++ b/update-db.js
@@ -5,11 +5,11 @@ var fs = require('fs')
 
 var BrowserslistError = require('./error')
 
-// eslint-disable-next-line consistent-return
 function filterPkg (dir, names) {
   if (names.indexOf('package.json') !== -1) {
     return path.join(dir, 'package.json')
   }
+  return ''
 }
 
 function detectLockfile () {

--- a/update-db.js
+++ b/update-db.js
@@ -1,12 +1,19 @@
 var childProcess = require('child_process')
-var pkgUp = require('pkg-up')
+var escalade = require('escalade/sync')
 var path = require('path')
 var fs = require('fs')
 
 var BrowserslistError = require('./error')
 
+// eslint-disable-next-line consistent-return
+function filterPkg (dir, names) {
+  if (names.indexOf('package.json') !== -1) {
+    return path.join(dir, 'package.json')
+  }
+}
+
 function detectLockfile () {
-  var packagePath = pkgUp.sync()
+  var packagePath = escalade('.', filterPkg)
   if (!packagePath) {
     throw new BrowserslistError(
       'Cannot find package.json. ' +

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,6 +2510,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+escalade@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-1.0.0.tgz#eba62cba84324dd46dc2ae4fbc15dd5088813e13"
+  integrity sha512-WvKmjtpItFC/A7e7XmgTv1bjoJRGirq6fTiV5MK9bmqD0fzWnH1AaVEby0dd3m9XVESNLrnPemSn5G9xcJn1UQ==
+
 escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,10 +2510,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escalade@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-1.0.0.tgz#eba62cba84324dd46dc2ae4fbc15dd5088813e13"
-  integrity sha512-WvKmjtpItFC/A7e7XmgTv1bjoJRGirq6fTiV5MK9bmqD0fzWnH1AaVEby0dd3m9XVESNLrnPemSn5G9xcJn1UQ==
+escalade@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-2.0.0.tgz#0a526670b38a29dd68cf82a019ac0e19599a4bd8"
+  integrity sha512-YOlYi0jO9/vqLYFrfyuGP/Hj4UrBPAoj75i0OKrJnbXG2QfIDPCJkJUZQAWE8t6EYiWgN0ZEyBcn/PMbqi8L9A==
 
 escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,10 +2510,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escalade@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-2.0.0.tgz#0a526670b38a29dd68cf82a019ac0e19599a4bd8"
-  integrity sha512-YOlYi0jO9/vqLYFrfyuGP/Hj4UrBPAoj75i0OKrJnbXG2QfIDPCJkJUZQAWE8t6EYiWgN0ZEyBcn/PMbqi8L9A==
+escalade@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.0.tgz#79b81f3c4bebb9c1727f0adba4b0f9d0ff050ca9"
+  integrity sha512-mA6h4UpYVBSxD7uq6y9RDtiYd9EMyuzITP1WgPKH2Gd0cDtnGP4LUrIoteH+BWRJfCXl94J/0dNfjUa45Oh+hQ==
 
 escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
The `pkg-up` makes up more than have of `browserslist`'s dependencies ([graph](https://npm.anvaka.com/#!/view/2d/browserslist)). It's pretty deceiving, actually.

Instead, `escalade` has zero dependencies, is more flexible, and is also faster ([results](https://github.com/lukeed/escalade#benchmarks)).
The `escalade/sync` version supports Node 6.x and above.

Finally, `pkg-up` (because of `find-up`) can be seen as a security issue since it traverses all the way up to your system's root directory (`/`). With `escalade`, traversal stops at the `process.cwd()` location.