### PR TITLE
Add explanation of and/or combinations in a human language.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ An `or` combiner can use the keyword `or` as well as `,`.
 
 `and` query combinations are also supported to perform an
 intersection of all the previous queries: `last 1 version or chrome > 75 and > 1%`,
-which in human words matches:
-`last 1 version of any browser with more than 1% of the market share and every version of chrome higher than 76 with more than 1% market share`.
+which in pseudo code matches:
+`match = (is browser last version OR is chrome since v76) &&  has more than 1% marketshare`
 
 There is 3 different ways to combine queries as depicted below. First you start
 with a single query and then we combine the queries to get our final list.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ An `or` combiner can use the keyword `or` as well as `,`.
 `last 1 version or > 1%` is equal to `last 1 version, > 1%`.
 
 `and` query combinations are also supported to perform an
-intersection of the previous query: `last 1 version and > 1%`.
+intersection of all the previous queries: `last 1 version or chrome > 75 and > 1%`,
+which in human words matches:
+`last 1 version of any browser with more than 1% of the market share and every version of chrome higher than 76 with more than 1% market share`.
 
 There is 3 different ways to combine queries as depicted below. First you start
 with a single query and then we combine the queries to get our final list.


### PR DESCRIPTION
Hello everyone and first of all many  thanks for inventing and maintaining this. Huge fan.

I was living in a wrong state of understanding how the queries work for some time. 

Today I started to dig into this topic while fighting with babel to stop transpiling `async..await` statements and after reading the README I started to be even more confused.

This PR already consists of small suggestion how to explain `and/or` combinations better but I treat this more like a starting point for further explanations (thanks in advance) or maybe even discussion whether there's a missing feature/bug that causes confusion.

## 1. Do I read it right?
So, as I understand from the README, every "and" statement applies to a previous query. 

Therefore this query:
`chrome > 75 or ie > 9 and last 1 version` should evaluate into:
`chrome > 75 or ie > 10`.

What I see both in the `npx browserslist` and on the website, this doesn't seem to be true:

Picture1: website screenshot:
<img width="729" alt="Screenshot 2020-06-24 at 22 01 31" src="https://user-images.githubusercontent.com/3393569/85623936-6c1eca80-b669-11ea-84a7-76505f14dfa4.png">

Picture2: IDE screenshot:
<img width="556" alt="Screenshot 2020-06-24 at 22 06 04" src="https://user-images.githubusercontent.com/3393569/85623965-7b9e1380-b669-11ea-8fa1-83edc1cc6cf1.png">

This is addressed directly in my PR by changing "previous query" into "all previous queries". Which seems to be what's actually happens.

Picture 3: website screenshot with moved `and` condition:
<img width="734" alt="Screenshot 2020-06-24 at 22 01 45" src="https://user-images.githubusercontent.com/3393569/85624138-b86a0a80-b669-11ea-8357-000c271cdf84.png">

## 2. package.json confusion

This discovery leads to a probable bigger issue with a package.json configuration.

This configuration (with having the above knowledge) would feel natural for me:
```json
"browserslist": [
    "chrome > 75",
    "ie > 9",
    "and last 1 version"
  ],
```

This however ends up with an error:
`browserslist: Unknown browser query `and last 1 version`. Maybe you are using old Browserslist or made typo in query.`

If I change it to a valid one:
```json
"browserslist": [
    "chrome > 75",
    "ie > 9 and last 1 version"
  ],
```

it's well, valid but without the knowledge above and given the "previous query" statement in the documentation, leads to unexpected behaviour evaluating to `(chrome > 75 or ie > 9) AND last 1 version`.

I don't really know if what I see is a bug or a future but the configuration above makes me think it's `chrome or (ie >9 and last 1 version)` because of the array notation and the fact that last two queries are bundled together. 

This however might be only my perception.

I'm looking forward hearing from you and again thanks for everything.

