### PR TITLE
use yarn info if necessary

### DIFF
--- a/update-db.js
+++ b/update-db.js
@@ -53,10 +53,16 @@ function getCurrentVersion (lock) {
   return null
 }
 
-function getLatestInfo () {
-  return JSON.parse(
-    childProcess.execSync('npm show caniuse-lite --json').toString()
-  )
+function getLatestInfo (lock) {
+  if (lock.mode !== 'yarn') {
+    return JSON.parse(
+      childProcess.execSync('npm show caniuse-lite --json').toString()
+    )
+  } else {
+    return JSON.parse(
+      childProcess.execSync('yarn info caniuse-lite --json').toString()
+    )
+  }
 }
 
 function updateLockfile (lock, latest) {
@@ -119,7 +125,7 @@ module.exports = function updateDB (print) {
   lock.content = fs.readFileSync(lock.file).toString()
 
   var current = getCurrentVersion(lock)
-  var latest = getLatestInfo()
+  var latest = getLatestInfo(lock)
 
   if (typeof current === 'string') {
     print('Current version: ' + current + '\n')

--- a/update-db.js
+++ b/update-db.js
@@ -61,7 +61,7 @@ function getLatestInfo (lock) {
   } else {
     return JSON.parse(
       childProcess.execSync('yarn info caniuse-lite --json').toString()
-    )
+    ).data
   }
 }
 


### PR DESCRIPTION
This pull request changes the code to use the `yarn info` command if `yarn.lock` is detected. 

Attempts to resolve issue #546 .

This is a work in progress, I might need help with the tests as this is my first PR to this project.