### PR TITLE
Respect --silent flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -75,6 +75,8 @@ if (isArg('--help') || isArg('-h')) {
       mode = 'json'
     } else if (name === '--mobile-to-desktop') {
       opts.mobileToDesktop = true
+    } else if (name === '--silent') {
+      opts.silent = true
     } else {
       error('Unknown arguments ' + args[i] + '.\n\n' + USAGE)
     }

--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ function browserslist (queries, opts) {
     env: opts.env
   }
 
-  env.oldDataWarning(browserslist.data)
+  if (!opts.silent) env.oldDataWarning(browserslist.data)
   var stats = env.getStat(opts, browserslist.data)
   if (stats) {
     context.customUsage = { }


### PR DESCRIPTION
This PR addresses issue #543.
If `--silent` flag is there in the command line then `oldDataWarning` check omitted completely.