### PR TITLE
Throw error on missing environment

### DIFF
--- a/node.js
+++ b/node.js
@@ -68,15 +68,20 @@ function pickEnv (config, opts) {
   if (typeof config !== 'object') return config
 
   var name
+
   if (typeof opts.env === 'string') {
     name = opts.env
   } else if (process.env.BROWSERSLIST_ENV) {
     name = process.env.BROWSERSLIST_ENV
-  } else if (process.env.NODE_ENV) {
-    name = process.env.NODE_ENV
-  } else {
-    name = 'production'
   }
+
+  if (name && name !== 'defaults' && !config[name]) {
+    throw new BrowserslistError(
+      'Missing config for Browserslist environment `' + name + '`.'
+    )
+  }
+
+  name = name || process.env.NODE_ENV || 'production'
 
   return config[name] || config.defaults
 }

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -191,8 +191,12 @@ it('uses env options to browserlist config', () => {
   expect(browserslist(null, { path: CONFIG, env: 'development' }))
     .toEqual(['chrome 55', 'firefox 50'])
 
-  expect(browserslist(null, { path: CONFIG, env: 'test' }))
+  expect(browserslist(null, { path: CONFIG, env: 'defaults' }))
     .toEqual(['ie 11', 'ie 10'])
+
+  expect(() => {
+    browserslist(null, { path: CONFIG, env: 'test' })
+  }).toThrow(/Missing config for Browserslist environment/)
 })
 
 it('uses env options to package.json', () => {
@@ -202,7 +206,12 @@ it('uses env options to package.json', () => {
   expect(browserslist(null, { path: PACKAGE, env: 'development' }))
     .toEqual(['chrome 55', 'firefox 50'])
 
-  expect(browserslist(null, { path: PACKAGE, env: 'test' })).toEqual(DEFAULTS)
+  expect(browserslist(null, { path: PACKAGE, env: 'defaults' }))
+    .toEqual(DEFAULTS)
+
+  expect(() => {
+    browserslist(null, { path: PACKAGE, env: 'test' })
+  }).toThrow(/Missing config for Browserslist environment/)
 })
 
 it('uses NODE_ENV to get environment', () => {


### PR DESCRIPTION
This PR introduces a check for missing environment configuration when explicitly providing an environment name, either by including it in `opts` or by providing it via the `BROWSERSLIST_ENV` environment variable.

It now throws an explicit error, whereas before it silently used the config defaults.

As discussed in #559, this is a breaking change.

Fixes #559. 