### PR TITLE
Add syntax highlight extension link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ So, if tool process `app/styles/main.css`, you can put config to root,
 
 You can specify direct path in `BROWSERSLIST_CONFIG` environment variables.
 
+
 ## Shareable Configs
 
 You can use the following query to reference an exported Browserslist config

--- a/README.md
+++ b/README.md
@@ -377,6 +377,9 @@ So, if tool process `app/styles/main.css`, you can put config to root,
 
 You can specify direct path in `BROWSERSLIST_CONFIG` environment variables.
 
+### Syntax Highlight
+
+You can add syntax highlighting in `.browserslistrc` and `browserslist` files by installing [browserslist extension](https://marketplace.visualstudio.com/items?itemName=webben.browserslist)
 
 ## Shareable Configs
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Browserslist will take queries from tool option,
 * [`browserslist-browserstack`] runs BrowserStack tests for all browsers
   in Browserslist config.
 * [`browserslist-adobe-analytics`] use Adobe Analytics data to target browsers.
+* [`browserslist-vscode`](https://marketplace.visualstudio.com/items?itemName=webben.browserslist) adds syntax highlighting for `.browserslistrc` and `browserslist` files. This is a [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marketplace.visualstudio.com/VSCode).
 * [`caniuse-api`] returns browsers which support some specific feature.
 * Run `npx browserslist` in your project directory to see project’s
   target browsers. This CLI tool is built-in and available in any project
@@ -376,10 +377,6 @@ So, if tool process `app/styles/main.css`, you can put config to root,
 `app/` or `app/styles`.
 
 You can specify direct path in `BROWSERSLIST_CONFIG` environment variables.
-
-### Syntax Highlight
-
-You can add syntax highlighting in `.browserslistrc` and `browserslist` files by installing [browserslist extension](https://marketplace.visualstudio.com/items?itemName=webben.browserslist)
 
 ## Shareable Configs
 


### PR DESCRIPTION
Closes #557

Created [extension](https://marketplace.visualstudio.com/items?itemName=webben.browserslist) to support browserslist config files syntax.

Highlights:
1. Comments (starts from #)
2. Version numbers (including `all`, `esr`, and `tp`) + `dead`
3. Market share in percents (50%, 0.5%, .5%)
4. `not, and, or, extends and ,` keywords + `>, >=, <=, <, in` operators
5. [Browser names](https://github.com/browserslist/browserslist#browsers)
6. Headers (`[production]`)
7. External config names (_not present in previews yet_)

I skipped __rare queries__ section for now, because I don't get the syntax rules yet, but I'll look up the browserslist source for inspiration :D

I also added previews into [repository](https://github.com/wspwebben/browserslist-highlight) for both dark and light themes, but for some reason they're not shown nor in vscode, nor in the marketplace.
