### PR TITLE
chore: warn to stdout instead of stderr

### DIFF
--- a/node.js
+++ b/node.js
@@ -370,7 +370,7 @@ module.exports = {
     var halfYearAgo = Date.now() - TIME_TO_UPDATE_CANIUSE
 
     if (latest !== 0 && latest < halfYearAgo) {
-      console.warn(
+      console.info(
         'Browserslist: caniuse-lite is outdated. Please run:\n' +
         'npx browserslist@latest --update-db\n' +
         '\n' +

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -85,7 +85,7 @@ let originSxists = fs.existsSync
 let originStat = fs.statSync
 
 beforeEach(() => {
-  jest.spyOn(console, 'warn').mockImplementation(() => true)
+  jest.spyOn(console, 'info').mockImplementation(() => true)
 })
 
 afterEach(() => {
@@ -103,7 +103,7 @@ afterAll(() => {
 it('does not print warning', () => {
   browserslist.data = youngerSixMonthsData
   browserslist('last 2 versions')
-  expect(console.warn).toHaveBeenCalledTimes(0)
+  expect(console.info).toHaveBeenCalledTimes(0)
 })
 
 it('shows warning', () => {
@@ -111,7 +111,7 @@ it('shows warning', () => {
   fs.existsSync = findPackage
   fs.statSync = mockStatSync
   browserslist('last 2 versions')
-  expect(console.warn).toHaveBeenCalledWith(
+  expect(console.info).toHaveBeenCalledWith(
     'Browserslist: caniuse-lite is outdated. Please run:\n' +
     'npx browserslist@latest --update-db\n' +
     '\n' +
@@ -126,7 +126,7 @@ it('hides warning on request', () => {
   fs.existsSync = findPackage
   fs.statSync = mockStatSync
   browserslist('last 2 versions')
-  expect(console.warn).toHaveBeenCalledTimes(0)
+  expect(console.info).toHaveBeenCalledTimes(0)
 })
 
 it('shows warning only once', () => {
@@ -135,5 +135,5 @@ it('shows warning only once', () => {
   fs.statSync = mockStatSync
   browserslist('last 2 versions')
   browserslist('last 2 versions')
-  expect(console.warn).toHaveBeenCalledTimes(1)
+  expect(console.info).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
## Motivation
Please always log actionable text to `STDOUT` instead of `STDERR`.  As per [The Open Group Base Specification](https://pubs.opengroup.org/onlinepubs/009695399/functions/stdin.html) on standard streams, `stderr` is used to indicate a non-zero exit code.  Some package managers like [rush](https://github.com/microsoft/rushstack/issues/1259) consider `stderr` output to indicate a non-zero exit status and probably others do as well following a convention to return the highest `FILENO` that is used as the exit status.

Notable verbiage
![TOG-Spec-STD-IO-Streams](https://user-images.githubusercontent.com/32680/106158919-3f2c1c00-6152-11eb-8c7c-025b73c04a7a.PNG)

I think the intention of the outdated `caniuse-lite` package warning is to provide actionable next steps to the user and not create an implied exit status when displayed.

### Supporting evidence
Searching Stack Overflow for the text `Browserslist: caniuse-lite is outdated` reveals many users confused why their builds are breaking and probably trying to do the right thing which is update their dependencies.  However I think it's worthwhile to consider the implications of which stream is being used and what exit status that implies.

### Reproducible steps
- create a `rush` project that has an outdated `caniuse-lite` browser list
- add an npm `build` script rush will invoke using built-in command and will generates the warning (similar to `lerna run build` but `build` is sugar the script name. (note: the built-in command will use the default settings) 
- add some some other script (example: `dist`)
- string together the `rush build` target and npm script and the  with `&&` (example)
```sh
rush build && pnpm run dist
```

*Expected*
* `dist` was run

*Actual*
* `dist` will not run as a non-zero exit status short circuits the logical expression

## Changelog
- replace `console.warn` with `console.info` in regards
- update tests to spy on `info`

Thanks so much for your time in considering this PR and I hope I speak for other users and not just my little corner of the world with the [Rush Stack](https://github.com/microsoft/rushstack).  
