### PR TITLE
Update DB - Support for artifactory (No integrity)

### DIFF
--- a/update-db.js
+++ b/update-db.js
@@ -135,9 +135,9 @@ function updateYarnLockfile (lock, latest) {
         lines[2] = lines[2].replace(
           /resolved "[^"]+"/, 'resolved "' + latest.dist.tarball + '"'
         )
-        lines[3] = lines[3].replace(
+        lines[3] = latest.dist.integrity ? lines[3].replace(
           /integrity .+/, 'integrity ' + latest.dist.integrity
-        )
+        ) : ''
       }
     }
   })


### PR DESCRIPTION
Fixes #592 

This makes the update db tool work when using artifactory to mirror the NPM registry.

In this case, integrity is not in latest.dist, shasum is used instead.

Leaving integrity out in this case makes yarn add it automatically.