### PR TITLE
browserslist updating warning: remove empty line

### DIFF
--- a/node.js
+++ b/node.js
@@ -376,7 +376,8 @@ module.exports = {
       console.warn(
         'Browserslist: caniuse-lite is outdated. Please run:\n' +
         '  npx browserslist@latest --update-db\n' +
-        '  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating'
+        '  Why you should do it regularly:' + 
+        'https://github.com/browserslist/browserslist#browsers-data-updating'
       )
     }
   },

--- a/node.js
+++ b/node.js
@@ -375,10 +375,8 @@ module.exports = {
     if (latest !== 0 && latest < halfYearAgo) {
       console.warn(
         'Browserslist: caniuse-lite is outdated. Please run:\n' +
-        'npx browserslist@latest --update-db\n' +
-        '\n' +
-        'Why you should do it regularly:\n' +
-        'https://github.com/browserslist/browserslist#browsers-data-updating'
+        '  npx browserslist@latest --update-db\n' +
+        '  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating'
       )
     }
   },

--- a/node.js
+++ b/node.js
@@ -376,7 +376,7 @@ module.exports = {
       console.warn(
         'Browserslist: caniuse-lite is outdated. Please run:\n' +
         '  npx browserslist@latest --update-db\n' +
-        '  Why you should do it regularly:' + 
+        '  Why you should do it regularly: ' + 
         'https://github.com/browserslist/browserslist#browsers-data-updating'
       )
     }

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -111,10 +111,8 @@ it('shows warning', () => {
   browserslist('last 2 versions')
   expect(console.warn).toHaveBeenCalledWith(
     'Browserslist: caniuse-lite is outdated. Please run:\n' +
-    'npx browserslist@latest --update-db\n' +
-    '\n' +
-    'Why you should do it regularly:\n' +
-    'https://github.com/browserslist/browserslist#browsers-data-updating'
+    '  npx browserslist@latest --update-db\n' +
+    '  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating'
   )
 })
 

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -112,7 +112,8 @@ it('shows warning', () => {
   expect(console.warn).toHaveBeenCalledWith(
     'Browserslist: caniuse-lite is outdated. Please run:\n' +
     '  npx browserslist@latest --update-db\n' +
-    '  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating'
+    '  Why you should do it regularly: ' +
+    'https://github.com/browserslist/browserslist#browsers-data-updating'
   )
 })
 


### PR DESCRIPTION
and make 3 lines (every line clearly belonging to browserslist), 2nd, 3rd with "  " double spaceindent.

This is to solve ugly output of build when this warning is shown many time and breaks output into unlogical sections with empty lines.

```
scripts:core:prod:standardEntryPoints: bundle start: "primary"
scripts:core:prod:sentry: Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
scripts:core:prod:disable-console: Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
scripts:core:prod:standardEntryPoints: Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating

```