### PR TITLE
fix: check file path when resolving shared configs

### DIFF
--- a/node.js
+++ b/node.js
@@ -161,7 +161,7 @@ module.exports = {
       checkExtend(name)
     }
     // eslint-disable-next-line security/detect-non-literal-require
-    var queries = require(require.resolve(name, { paths: ['.'] }))
+    var queries = require(require.resolve(name, { paths: ['.', ctx.path] }))
     if (queries) {
       if (Array.isArray(queries)) {
         return queries


### PR DESCRIPTION
Fixes stylelint/vscode-stylelint#108

Currently, only the current working directory is checked when resolving shareable configs. However, in certain instances, browserslist may be running outside of the directory in which the file referencing the config is found. This fix adds the context's path as a fallback when resolving shareable configs.