### PR TITLE
Fix edge case of `since` query (fix #646)

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,7 +209,8 @@ function filterByYear(since, context) {
     var data = byName(name, context)
     if (!data) return selected
     var versions = Object.keys(data.releaseDate).filter(function (v) {
-      return data.releaseDate[v] >= since
+      var date = data.releaseDate[v]
+      return date !== null && date >= since
     })
     return selected.concat(versions.map(nameMapper(data.name)))
   }, [])

--- a/test/since.test.js
+++ b/test/since.test.js
@@ -14,6 +14,15 @@ beforeEach(() => {
         2: 1483228800, // Sun, 01 Jan 2017 00:00:00 +0000
         3: 1485907200 // Wed, 01 Feb 2017 00:00:00 +0000
       }
+    },
+    safari: {
+      name: 'safari',
+      versions: ['TP'],
+      released: [],
+      releaseDate: {
+        1: 1451606400, // Fri, 01 Jan 2016 00:00:00 +0000
+        TP: null // unreleased
+      }
     }
   }
   console.warn = function (...args) {
@@ -28,11 +37,11 @@ afterEach(() => {
 })
 
 it('selects versions released on year boundaries', () => {
-  expect(browserslist('since 1970')).toEqual(['ie 3', 'ie 2', 'ie 1'])
+  expect(browserslist('since 1970')).toEqual(['ie 3', 'ie 2', 'ie 1', 'safari 1'])
 })
 
 it('is case insensitive', () => {
-  expect(browserslist('Since 1970')).toEqual(['ie 3', 'ie 2', 'ie 1'])
+  expect(browserslist('Since 1970')).toEqual(['ie 3', 'ie 2', 'ie 1', 'safari 1'])
 })
 
 it('selects versions released on year and month boundaries', () => {


### PR DESCRIPTION
This PR adds a check that makes sure release date won't be `null`.