### PR TITLE
Make `cover` query case-insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -642,7 +642,7 @@ function coverQuery(context, coverage, statMode) {
   coverage = parseFloat(coverage)
   var usage = browserslist.usage.global
   if (statMode) {
-    if (statMode.match(/^my\s+stats$/)) {
+    if (statMode.match(/^my\s+stats$/i)) {
       if (!context.customUsage) {
         throw new BrowserslistError('Custom usage statistics was not provided')
       }
@@ -916,11 +916,11 @@ var QUERIES = [
     }
   },
   {
-    regexp: /^cover\s+(\d+|\d+\.\d+|\.\d+)%$/,
+    regexp: /^cover\s+(\d+|\d+\.\d+|\.\d+)%$/i,
     select: coverQuery
   },
   {
-    regexp: /^cover\s+(\d+|\d+\.\d+|\.\d+)%\s+in\s+(my\s+stats|(alt-)?\w\w)$/,
+    regexp: /^cover\s+(\d+|\d+\.\d+|\.\d+)%\s+in\s+(my\s+stats|(alt-)?\w\w)$/i,
     select: coverQuery
   },
   {

--- a/test/cover.test.js
+++ b/test/cover.test.js
@@ -32,8 +32,16 @@ it('adds at least one browser', () => {
   expect(browserslist('cover 1% in my stats')).toEqual(['ie 11'])
 })
 
+it('is case insensitive for custom stat', () => {
+  expect(browserslist('Cover 1% In My Stats')).toEqual(['ie 11'])
+})
+
 it('global coverage', () => {
   expect(browserslist('cover 0.1%')).toEqual(['ie 5'])
+})
+
+it('is case insensitive for global coverage', () => {
+  expect(browserslist('Cover 0.1%')).toEqual(['ie 5'])
 })
 
 it('country coverage', () => {
@@ -42,6 +50,11 @@ it('country coverage', () => {
 
 it('country coverage alt', () => {
   expect(browserslist('cover 0.1% in alt-us')).toEqual(['ie 8'])
+})
+
+it('is case insensitive for country coverage', () => {
+  expect(browserslist('Cover 0.1% in us')).toEqual(['ie 9'])
+  expect(browserslist('Cover 0.1% in Alt-US')).toEqual(['ie 8'])
 })
 
 it('adds browsers by popularity', () => {


### PR DESCRIPTION
This PR makes `cover` query case-insensitive, which allows:

```
Cover 1%
Cover 1% In My Stats
Cover 1% in us
Cover 1% In Alt-US
```