### PR TITLE
Add grammar definition

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ coverage/
 .github/
 img/
 tsconfig.json
+grammar.w3c-ebnf

--- a/README.md
+++ b/README.md
@@ -278,6 +278,10 @@ You can add `not ` to any query.
 [Can I Use]:                   https://caniuse.com/
 [Firefox Extended Support Release]: https://support.mozilla.org/en-US/kb/choosing-firefox-update-channel
 
+### Grammar Definition
+
+There is a [grammar specification](./grammar.w3c-ebnf) about the query syntax,
+which may be helpful if you're implementing a parser or something else.
 
 ### Debug
 

--- a/grammar.w3c-ebnf
+++ b/grammar.w3c-ebnf
@@ -38,7 +38,7 @@ BrowserName ::= 'ie'
   | 'ucandroid'
   | 'qqandroid'
 
-OperatorCompare = ('>' | '<') '='?
+OperatorCompare ::= ('>' | '<') '='?
 
 KeywordVersion ::= 'version' 's'?
 

--- a/grammar.w3c-ebnf
+++ b/grammar.w3c-ebnf
@@ -1,0 +1,90 @@
+NonSpaceChar ::= [#x21-#xD7FF] | [#xE000-#xFFFD]
+
+Digit ::= [0-9]
+
+Space ::= ' ' | '\n' | '\t' | '\r' | '\f'
+
+Numeric ::= (Digit* '.')? Digit+
+
+KeywordVersion ::= 'version' 's'?
+
+LastBrowsers ::= 'last' Space+ Digit+ Space+ (BrowserName Space+)? ('major' Space+)? KeywordVersion
+
+LastElectron ::= 'last' Space+ Digit+ Space+ 'electron' Space+ ('major' Space+)? KeywordVersion
+
+Unreleased ::= 'unreleased' Space+ ((BrowserName | 'electron') Space+)? KeywordVersion
+
+Years ::= 'last' Space+ Numeric Space+ 'year' 's'?
+
+Since ::= 'since' Space Digit+ ('-' Digit+ ('-' Digit+)?)?
+
+Region ::= ('alt-' [a-z][a-z] | [A-Z][A-Z])
+
+MyStats ::= 'my' Space+ 'stats'
+
+CustomStats ::= NonSpaceChar+ Space+ 'stats'
+
+Percentage ::= ('>' | '<') '='? Space* Numeric '%' (Space+ 'in' Space+ (MyStats | CustomStats | Region))?
+
+Cover ::= 'cover' Space+ Numeric '%' (Space+ 'in' Space+ (MyStats | Region))?
+
+FeatureSupport ::= 'supports' Space+ ([a-z0-9] | '-')+
+
+Version ::= (Digit | '.')+
+
+BoundedRange ::= Version Space* '-' Space* Version
+
+UnboundedRange ::= ('>' | '<') '='? Space* Version
+
+Electron ::= 'electron' Space+ (BoundedRange | UnboundedRange | Version)
+
+Node ::= 'node' Space+ (BoundedRange | UnboundedRange | Version)
+
+Browser ::= BrowserName Space+ (BoundedRange | UnboundedRange | Version | 'tp')
+
+FirefoxESR ::= ('firefox' | 'fx' | 'ff') Space+ 'esr'
+
+OperaMini ::= ('operamini' | 'op_mini') Space+ 'all'
+
+CurrentNode ::= 'current' Space+ 'node'
+
+MaintainedNode ::= 'maintained' Space+ 'node' Space+ 'versions'
+
+Phantom ::= 'phantomjs' Space+ ('1.9' | '2.1')
+
+BrowserslistConfig ::= 'browserslist config'
+
+Extending ::= 'extends' Space NonSpaceChar+
+
+Defaults ::= 'defaults'
+
+Dead ::= 'dead'
+
+QueryAtom ::= LastBrowsers
+    | LastElectron
+    | Unreleased
+    | Years
+    | Since
+    | Percentage
+    | Cover
+    | FeatureSupport
+    | Electron
+    | Node
+    | Browser
+    | FirefoxESR
+    | OperaMini
+    | CurrentNode
+    | MaintainedNode
+    | Phantom
+    | BrowserslistConfig
+    | Extending
+    | Defaults
+    | Dead
+
+SingleQuery ::= ('not' Space)? QueryAtom
+
+OperatorOr ::= Space+ 'or' Space+ | Space* ',' Space*
+
+OperatorAnd ::= Space+ 'and' Space+
+
+BrowserslistQuery ::= QueryAtom ((OperatorOr | OperatorAnd) SingleQuery)*

--- a/grammar.w3c-ebnf
+++ b/grammar.w3c-ebnf
@@ -6,6 +6,38 @@ Space ::= ' ' | '\n' | '\t' | '\r' | '\f'
 
 Numeric ::= (Digit* '.')? Digit+
 
+BrowserName ::= 'ie'
+  | 'edge'
+  | 'firefox'
+  | 'chrome'
+  | 'safari'
+  | 'opera'
+  | 'ios_saf'
+  | 'op_mini'
+  | 'android'
+  | 'bb'
+  | 'op_mob'
+  | 'and_chr'
+  | 'and_ff'
+  | 'ie_mob'
+  | 'and_uc'
+  | 'samsung'
+  | 'and_qq'
+  | 'baidu'
+  | 'kaios'
+  | 'fx'
+  | 'ff'
+  | 'ios'
+  | 'explorer'
+  | 'blackberry'
+  | 'explorermobile'
+  | 'operamini'
+  | 'operamobile'
+  | 'chromeandroid'
+  | 'firefoxandroid'
+  | 'ucandroid'
+  | 'qqandroid'
+
 KeywordVersion ::= 'version' 's'?
 
 LastBrowsers ::= 'last' Space+ Digit+ Space+ (BrowserName Space+)? ('major' Space+)? KeywordVersion
@@ -61,25 +93,25 @@ Defaults ::= 'defaults'
 Dead ::= 'dead'
 
 QueryAtom ::= LastBrowsers
-    | LastElectron
-    | Unreleased
-    | Years
-    | Since
-    | Percentage
-    | Cover
-    | FeatureSupport
-    | Electron
-    | Node
-    | Browser
-    | FirefoxESR
-    | OperaMini
-    | CurrentNode
-    | MaintainedNode
-    | Phantom
-    | BrowserslistConfig
-    | Extending
-    | Defaults
-    | Dead
+  | LastElectron
+  | Unreleased
+  | Years
+  | Since
+  | Percentage
+  | Cover
+  | FeatureSupport
+  | Electron
+  | Node
+  | Browser
+  | FirefoxESR
+  | OperaMini
+  | CurrentNode
+  | MaintainedNode
+  | Phantom
+  | BrowserslistConfig
+  | Extending
+  | Defaults
+  | Dead
 
 SingleQuery ::= ('not' Space)? QueryAtom
 

--- a/grammar.w3c-ebnf
+++ b/grammar.w3c-ebnf
@@ -38,15 +38,15 @@ BrowserName ::= 'ie'
   | 'ucandroid'
   | 'qqandroid'
 
-OperatorCompare ::= ('>' | '<') '='?
+CompareOperator ::= ('>' | '<') '='?
 
-KeywordVersion ::= 'version' 's'?
+VersionKeyword ::= 'version' 's'?
 
-LastBrowsers ::= 'last' Space+ Digit+ Space+ (BrowserName Space+)? ('major' Space+)? KeywordVersion
+LastBrowsers ::= 'last' Space+ Digit+ Space+ (BrowserName Space+)? ('major' Space+)? VersionKeyword
 
-LastElectron ::= 'last' Space+ Digit+ Space+ 'electron' Space+ ('major' Space+)? KeywordVersion
+LastElectron ::= 'last' Space+ Digit+ Space+ 'electron' Space+ ('major' Space+)? VersionKeyword
 
-Unreleased ::= 'unreleased' Space+ ((BrowserName | 'electron') Space+)? KeywordVersion
+Unreleased ::= 'unreleased' Space+ ((BrowserName | 'electron') Space+)? VersionKeyword
 
 Years ::= 'last' Space+ Numeric Space+ 'year' 's'?
 
@@ -58,7 +58,7 @@ MyStats ::= 'my' Space+ 'stats'
 
 CustomStats ::= NonSpaceChar+ Space+ 'stats'
 
-Percentage ::= OperatorCompare Space* Numeric '%' (Space+ 'in' Space+ (MyStats | CustomStats | Region))?
+Percentage ::= CompareOperator Space* Numeric '%' (Space+ 'in' Space+ (MyStats | CustomStats | Region))?
 
 Cover ::= 'cover' Space+ Numeric '%' (Space+ 'in' Space+ (MyStats | Region))?
 
@@ -68,7 +68,7 @@ Version ::= (Digit | '.')+
 
 BoundedRange ::= Version Space* '-' Space* Version
 
-UnboundedRange ::= OperatorCompare Space* Version
+UnboundedRange ::= CompareOperator Space* Version
 
 Electron ::= 'electron' Space+ (BoundedRange | UnboundedRange | Version)
 
@@ -117,8 +117,8 @@ QueryAtom ::= LastBrowsers
 
 SingleQuery ::= ('not' Space)? QueryAtom
 
-OperatorOr ::= Space+ 'or' Space+ | Space* ',' Space*
+OrOperator ::= Space+ 'or' Space+ | Space* ',' Space*
 
-OperatorAnd ::= Space+ 'and' Space+
+AndOperator ::= Space+ 'and' Space+
 
-BrowserslistQuery ::= QueryAtom ((OperatorOr | OperatorAnd) SingleQuery)*
+BrowserslistQuery ::= QueryAtom ((OrOperator | AndOperator) SingleQuery)*

--- a/grammar.w3c-ebnf
+++ b/grammar.w3c-ebnf
@@ -38,6 +38,8 @@ BrowserName ::= 'ie'
   | 'ucandroid'
   | 'qqandroid'
 
+OperatorCompare = ('>' | '<') '='?
+
 KeywordVersion ::= 'version' 's'?
 
 LastBrowsers ::= 'last' Space+ Digit+ Space+ (BrowserName Space+)? ('major' Space+)? KeywordVersion
@@ -56,7 +58,7 @@ MyStats ::= 'my' Space+ 'stats'
 
 CustomStats ::= NonSpaceChar+ Space+ 'stats'
 
-Percentage ::= ('>' | '<') '='? Space* Numeric '%' (Space+ 'in' Space+ (MyStats | CustomStats | Region))?
+Percentage ::= OperatorCompare Space* Numeric '%' (Space+ 'in' Space+ (MyStats | CustomStats | Region))?
 
 Cover ::= 'cover' Space+ Numeric '%' (Space+ 'in' Space+ (MyStats | Region))?
 
@@ -66,7 +68,7 @@ Version ::= (Digit | '.')+
 
 BoundedRange ::= Version Space* '-' Space* Version
 
-UnboundedRange ::= ('>' | '<') '='? Space* Version
+UnboundedRange ::= OperatorCompare Space* Version
 
 Electron ::= 'electron' Space+ (BoundedRange | UnboundedRange | Version)
 

--- a/grammar.w3c-ebnf
+++ b/grammar.w3c-ebnf
@@ -122,3 +122,5 @@ OrOperator ::= Space+ 'or' Space+ | Space* ',' Space*
 AndOperator ::= Space+ 'and' Space+
 
 BrowserslistQuery ::= QueryAtom ((OrOperator | AndOperator) SingleQuery)*
+
+Root ::= BrowserslistQuery

--- a/grammar.w3c-ebnf
+++ b/grammar.w3c-ebnf
@@ -2,7 +2,7 @@ NonSpaceChar ::= [#x21-#xD7FF] | [#xE000-#xFFFD]
 
 Digit ::= [0-9]
 
-Space ::= ' ' | '\n' | '\t' | '\r' | '\f'
+Space ::= ' ' | '\t'
 
 Numeric ::= (Digit* '.')? Digit+
 


### PR DESCRIPTION
Added a grammar definition file as reference.

I adopted [W3C-style EBNF](https://www.w3.org/TR/2010/REC-xquery-20101214/#EBNFNotation) as notation syntax.
To visualize the definition, open [Railroad Diagram Generator](https://bottlecaps.de/rr/ui),
then switch to the "Edit Grammar" tab and paste the definition text into the editor,
then switch to the "View Diagram" tab, and we can see the result.

For those inconvenient to do that, here is a screenshot of the "last" query:

![image](https://user-images.githubusercontent.com/17216317/145187411-857493d4-7562-4893-95a7-8c18d500a655.png)

Fixes #421 
Fixes #641 