### PR TITLE
fix: array index overflow

### DIFF
--- a/index.js
+++ b/index.js
@@ -665,7 +665,7 @@ function coverQuery(context, coverage, statMode) {
   var coveraged = 0
   var result = []
   var version
-  for (var i = 0; i <= versions.length; i++) {
+  for (var i = 0; i < versions.length; i++) {
     version = versions[i]
     if (usage[version] === 0) break
     coveraged += usage[version]


### PR DESCRIPTION
I'm sorry, but I think this is an obvious mistake. In the last loop it causes `version` to be necessarily `undefined`, which causes an error in the subsequent code.

This error can be triggered in a simple way:

1. Create a `browserslist-stats.json` file and add some simple data to it.

```json
{
  "chrome": {
    "90": 50
  }
}
```

2. Set a coverage rate that exceeds the sum in stats file and execute the CLI.

```shell
npx browserslist "cover 99% in my stats"
```

I think the expected case for the above behavior should be to include all the specified browser versions, but currently it throws an error:

```
/[CWD]/node_modules/browserslist/cli.js:94
      throw e
      ^

TypeError: Cannot read properties of undefined (reading 'split')
    at /[CWD]/node_modules/browserslist/index.js:342:25
    at Array.map (<anonymous>)
    at /[CWD]/node_modules/browserslist/index.js:341:59
    at Array.reduce (<anonymous>)
    at resolve (/[CWD]/node_modules/browserslist/index.js:320:18)
    at browserslist (/[CWD]/node_modules/browserslist/index.js:450:21)
    at Object.<anonymous> (/[CWD]/node_modules/browserslist/cli.js:89:16)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
```