### PR TITLE
feat: added option to throw on missing env

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ Options:
   Default is `false`.
 * `dangerousExtend`: Disable security checks for `extend` query.
   Default is `false`.
+* `throwOnMissing`: throw a error if env is not found.
+  Default is `false`.
 * `mobileToDesktop`: Use desktop browsers if Can I Use doesn’t have data
   about this mobile version. Can I Use has only data only about
   latest versions of mobile browsers. By default, `last 2 and_ff versions`

--- a/index.js
+++ b/index.js
@@ -397,6 +397,7 @@ var cache = {}
  *                                                     version in direct query.
  * @param {boolean} [opts.dangerousExtend] Disable security checks
  *                                         for extend query.
+ * @param {boolean} [opts.throwOnMissing] Throw error on missing env.
  * @param {boolean} [opts.mobileToDesktop] Alias mobile browsers to the desktop
  *                                         version when Can I Use doesn't have
  *                                         data about the specified version.

--- a/node.js
+++ b/node.js
@@ -82,6 +82,14 @@ function pickEnv(config, opts) {
     name = 'production'
   }
 
+  if (opts.throwOnMissing) {
+    if (name && name !== 'defaults' && !config[name]) {
+      throw new BrowserslistError(
+        'Missing config for Browserslist environment `' + name + '`.'
+      )
+    }
+  }
+  
   return config[name] || config.defaults
 }
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -260,4 +260,18 @@ test('correctly works with not and one-version browsers', () => {
   is(browserslist('last 1 Baidu version, not <2% in AT').length, 0)
 })
 
+test('throws error on missing env in config', () => {
+  throws(
+    () => browserslist(['not ie 11'], { path: CONFIG, throwOnMissing: true, env: 'test' }),
+    "Missing config for Browserslist environment 'test'."
+  )
+})
+
+test('throws error on missing env in package.json', () => {
+  throws(
+    () => browserslist(['not ie 11'], { path: PACKAGE, throwOnMissing: true, env: 'test' }),
+    "Missing config for Browserslist environment 'test'."
+  )
+})
+
 test.run()

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -260,17 +260,22 @@ test('correctly works with not and one-version browsers', () => {
   is(browserslist('last 1 Baidu version, not <2% in AT').length, 0)
 })
 
-test('throws error on missing env in config', () => {
+test('throws error on missing env', () => {
   throws(
-    () => browserslist(['not ie 11'], { path: CONFIG, throwOnMissing: true, env: 'test' }),
+    () => browserslist(null, { path: PACKAGE, throwOnMissing: true, env: 'test' }),
     "Missing config for Browserslist environment 'test'."
   )
 })
 
-test('throws error on missing env in package.json', () => {
-  throws(
-    () => browserslist(['not ie 11'], { path: PACKAGE, throwOnMissing: true, env: 'test' }),
-    "Missing config for Browserslist environment 'test'."
+test('does not throw error on missing defaults env', () => {
+  equal(
+    browserslist(null, { path: PACKAGE, throwOnMissing: true, env: 'defaults' }), DEFAULTS
+  )
+})
+
+test('does not throw error on missing env', () => {
+  equal(
+    browserslist(null, { path: PACKAGE, throwOnMissing: false, env: 'test' }), DEFAULTS
   )
 })
 


### PR DESCRIPTION
Based on https://github.com/browserslist/browserslist/pull/560

* Added `throwOnMissing` option to browserslist
* Added tests for `throwOnMissing` option to browserslist
* Added jsdoc for option but found no script for updating .d.ts
* Coverage not full but can't figure out why