### PR TITLE
Update Firefox ESR versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1054,7 +1054,7 @@ var QUERIES = [
   {
     regexp: /^(firefox|ff|fx)\s+esr$/i,
     select: function () {
-      return ['firefox 78', 'firefox 91']
+      return ['firefox 91']
     }
   },
   {


### PR DESCRIPTION
Firefox 78 is not an ESR anymore since November 2021.