### PR TITLE
README: fix name for Edge on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The following table maps browser names & their target devices into identifiers u
 | Baidu             | `Baidu`          |                           |                          |                   |
 | BlackBerry        |                  |                           |                          | `BlackBerry` `bb` |
 | Chrome            | `Chrome`         | `ChromeAndroid` `and_chr` | ↪︎ `ios_saf`<sup>2</sup>  |                   |
-| Edge              | `Edge`           | ↪︎ `and_chrome`            | ↪︎ `ios_saf`<sup>2</sup>  |                   |
+| Edge              | `Edge`           | ↪︎ `and_chr`               | ↪︎ `ios_saf`<sup>2</sup>  |                   |
 | Electron          | `Electron`       |                           |                          |                   |
 | Firefox           | `Firefox` `ff`   | `FirefoxAndroid` `and_ff` | ↪︎ `ios_saf`<sup>2</sup>  |                   |
 | Internet Explorer | `Explorer` `ie`  |                           |                          | `ie_mob`          |


### PR DESCRIPTION
`and_chrome` is not a part of the Browserslist [query grammar](https://github.com/browserslist/browserslist/blob/main/grammar.w3c-ebnf). Fixed by replacing with `and_chr`.