### PR TITLE
Mark Baidu browser as dead

### DIFF
--- a/index.js
+++ b/index.js
@@ -1157,7 +1157,7 @@ var QUERIES = [
     regexp: /^browserslist config$/i,
     select: function (context) {
       return browserslist(undefined, context)
-    }
+    }
   },
   {
     regexp: /^extends (.+)$/i,
@@ -1175,6 +1175,7 @@ var QUERIES = [
     regexp: /^dead$/i,
     select: function (context) {
       var dead = [
+        'Baidu >= 0',
         'ie <= 10',
         'ie_mob <= 11',
         'bb <= 10',

--- a/index.js
+++ b/index.js
@@ -1157,7 +1157,7 @@ var QUERIES = [
     regexp: /^browserslist config$/i,
     select: function (context) {
       return browserslist(undefined, context)
-    }
+    }
   },
   {
     regexp: /^extends (.+)$/i,


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Baidu_Browser), Baidu browser was deprecated in April 2019 (36 months ago). As stated in the README, "browsers without official support or updates for 24 months" are marked as "dead".