### PR TITLE
Mark Internet Explorer as dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ You can specify the browser and Node.js versions by queries (case insensitive):
   * `last 2 major versions` or `last 2 iOS major versions`:
     all minor/patch releases of last 2 major versions.
 * `dead`: browsers without official support or updates for 24 months.
-  Right now it is `IE 10`, `IE_Mob 11`, `BlackBerry 10`, `BlackBerry 7`,
+  Right now it is `IE 11`, `IE_Mob 11`, `BlackBerry 10`, `BlackBerry 7`,
   `Samsung 4`, `OperaMobile 12.1` and all versions of `Baidu`.
 * Node.js versions:
   * `node 10` and `node 10.4`: selects latest Node.js `10.x.x`

--- a/index.js
+++ b/index.js
@@ -1176,7 +1176,7 @@ var QUERIES = [
     select: function (context) {
       var dead = [
         'Baidu >= 0',
-        'ie <= 10',
+        'ie <= 11',
         'ie_mob <= 11',
         'bb <= 10',
         'op_mob <= 12.1',


### PR DESCRIPTION
This PR updates the list of dead browsers to include IE 11. Per #699, this should not be merged immediately.
Closes #699