### PR TITLE
Add "since COVID" and "post-COVID" queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var env = require('./node') // Will load browser.js in webpack
 
 var YEAR = 365.259641 * 24 * 60 * 60 * 1000
 var ANDROID_EVERGREEN_FIRST = 37
+var COVID_QUERY = "since 2019-12-01"; // First known case
 
 // Helpers
 
@@ -735,6 +736,13 @@ var QUERIES = {
     matches: ['year', 'month', 'day'],
     regexp: /^since (\d+)-(\d+)-(\d+)$/i,
     select: sinceQuery
+  },
+  since_covid: {
+    matches: [],
+    regexp: /^(since |post-)covid$/i,
+    select: function (context) {
+      return resolve(COVID_QUERY, context)
+    }
   },
   popularity: {
     matches: ['sign', 'popularity'],

--- a/test/covid.test.js
+++ b/test/covid.test.js
@@ -1,0 +1,55 @@
+let { test } = require('uvu')
+let { equal } = require('uvu/assert')
+
+delete require.cache[require.resolve('..')]
+let browserslist = require('..')
+
+let originData = { ...browserslist.data }
+let originWarn = console.warn
+
+test.before.each(() => {
+  browserslist.data = {
+    chrome: {
+      name: 'chrome',
+      versions: ['1', '2', '3'],
+      released: [],
+      releaseDate: {
+        1: 0, // 01 Jan 1970 00:00:00 +0000
+        2: 1485907200, // 01 Feb 2017 00:00:00 +0000
+        3: 1609459200 // 01 Jan 2021 00:00:00 +0000
+      }
+    },
+    safari: {
+      name: 'safari',
+      versions: ['TP'],
+      released: [],
+      releaseDate: {
+        1: 1575244800, // 02 Dec 2019 00:00:00 +0000
+        TP: null // unreleased
+      }
+    }
+  }
+  console.warn = function (...args) {
+    if (args[0].includes('update-browserslist-db')) return
+    originWarn.apply(this, args)
+  }
+})
+
+test.after.each(() => {
+  browserslist.data = originData
+  console.warn = originWarn
+})
+
+test('selects versions released after COVID', () => {
+  equal(browserslist('since covid'), ['chrome 3', 'safari 1'])
+})
+
+test('is case insensitive', () => {
+  equal(browserslist('Since COVID'), ['chrome 3', 'safari 1'])
+})
+
+test('works with alternate spelling', () => {
+  equal(browserslist('post-COVID'), ['chrome 3', 'safari 1'])
+})
+
+test.run()


### PR DESCRIPTION
The cultural importance of COVID cannot be overstated. It marks the beginning of a new era, one in which an action as simple as going outside might be deadly. Because of the major changes it introduced into our lives, as well as trauma that cannot be forgotten, many use it as a date signifier even in contexts unrelated to the pandemic itself. Consider the phrases ["pre-COVID"](https://trends.google.com/trends/explore?date=today%205-y&geo=US&q=pre-covid) and "post-COVID".

I think it is appropriate to add "since COVID" and "post-COVID" as valid Browserslist queries. I'll understand if you disagree, though.