### PR TITLE
Add WebStorm plugin reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ These extensions will add syntax highlighting for `.browserslistrc` files.
 
 * [VS Code](https://marketplace.visualstudio.com/items?itemName=webben.browserslist)
 * [Vim](https://github.com/browserslist/vim-browserslist)
+* [WebStorm](https://plugins.jetbrains.com/plugin/16139-browserslist)
 
 ## Best Practices
 


### PR DESCRIPTION
It also works for other paid JB IDEs, because they are more expensive than WS and include JS support :smile: But that's too long to explain in the README.md.