### PR TITLE
Fix typo in `throwOnMissing` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Options:
   Default is `false`.
 * `dangerousExtend`: Disable security checks for `extend` query.
   Default is `false`.
-* `throwOnMissing`: throw a error if env is not found.
+* `throwOnMissing`: throw an error if env is not found.
   Default is `false`.
 * `mobileToDesktop`: Use desktop browsers if Can I Use doesn’t have data
   about this mobile version. Can I Use has only data only about

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ declare namespace browserslist {
      */
     ignoreUnknownVersions?: boolean
     /**
-     * Throw a error if env is not found.
+     * Throw an error if env is not found.
      */
     throwOnMissing?: boolean
     /**

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -83,7 +83,7 @@ test('handles undefined stats and path correctly', () => {
   equal(browserslist([], config), [])
 })
 
-test('throw a error on wrong path to config', () => {
+test('throw an error on wrong path to config', () => {
   throws(() => browserslist(null, { config: IE + '2' }), /Can't read/)
 })
 


### PR DESCRIPTION
I noticed a small typo in the description and tests of the `throwOnMissing` parameter