### PR TITLE
Throw errors on wrong feature and region names from Can I Use

### DIFF
--- a/node.js
+++ b/node.js
@@ -263,8 +263,12 @@ module.exports = {
   loadFeature: function loadFeature(features, name) {
     name = name.replace(/[^\w-]/g, '')
     if (features[name]) return
-
-    var compressed = require('caniuse-lite/data/features/' + name + '.js')
+    var compressed
+    try {
+      compressed = require('caniuse-lite/data/features/' + name + '.js')
+    } catch (e) {
+      throw new BrowserslistError("Unknown feature name `" + name + "`.")
+    }
     var stats = feature(compressed).stats
     features[name] = {}
     for (var i in stats) {

--- a/node.js
+++ b/node.js
@@ -243,7 +243,12 @@ module.exports = {
   loadCountry: function loadCountry(usage, country, data) {
     var code = country.replace(/[^\w-]/g, '')
     if (!usage[code]) {
-      var compressed = require('caniuse-lite/data/regions/' + code + '.js')
+      var compressed
+      try {
+        compressed = require('caniuse-lite/data/regions/' + code + '.js')
+      } catch (e) {
+        throw new BrowserslistError("Unknown region name `" + code + "`.")
+      }
       var usageData = region(compressed)
       normalizeUsageData(usageData, data)
       usage[country] = {}

--- a/test/country.test.js
+++ b/test/country.test.js
@@ -1,5 +1,5 @@
 let { test } = require('uvu')
-let { is, equal } = require('uvu/assert')
+let { is, equal, throws } = require('uvu/assert')
 
 delete require.cache[require.resolve('..')]
 let browserslist = require('..')
@@ -71,8 +71,16 @@ test('loads country from Can I Use', () => {
   is(browserslist('> 1% in RU').length > 0, true)
 })
 
+test('throw an error on wrong country name from Can I Use', () => {
+  throws(() => browserslist('> 1% in __'), /Unknown region name/)
+})
+
 test('loads continents from Can I Use', () => {
   is(browserslist('> 1% in alt-AS').length > 0, true)
+})
+
+test('throw an error on wrong continent name from Can I Use', () => {
+  throws(() => browserslist('> 1% in alt-__'), /Unknown region name/)
 })
 
 test('allows omission of the space between the > and the percentage', () => {

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -1,5 +1,5 @@
 let { test } = require('uvu')
-let { equal, is } = require('uvu/assert')
+let { equal, is, throws } = require('uvu/assert')
 
 delete require.cache[require.resolve('..')]
 let browserslist = require('..')
@@ -22,6 +22,10 @@ test.after.each(() => {
 
 test('load features from Can I Use', () => {
   is(browserslist('supports objectrtc').length > 0, true)
+})
+
+test('throw an error on wrong feature name from Can I Use', () => {
+  throws(() => browserslist('supports wrong-feature-name'), /Unknown feature name/)
 })
 
 test('selects browsers by feature', () => {


### PR DESCRIPTION
## Problem
Recently I made mistakes in queries that use caniuse-lite data. It's regional usage statistics query `>0% in [Region]` and feature support query `supports [feature-name]` .

Browserslist crashes and **doesn't output** errors to the user. It seems that the Browserslist, as in other cases, should indicate user errors (especially if the request consists of several parts).

_Other discussions about one of these problems: https://github.com/browserslist/browserslist/issues/684, https://github.com/PSPDFKit-labs/browserslist.dev/issues/39_

## Bad requests examples


### Supports

`'supports replace-all'` — example from Issue https://github.com/browserslist/browserslist/issues/684
<details>
<summary>Error message</summary>

```
➜  ~ npx browserslist 'supports replace-all'
/usr/local/lib/node_modules/browserslist/cli.js:96
      throw e
      ^

Error: Cannot find module 'caniuse-lite/data/features/replace-all.js'
```

</details>



### Region

`'>2% in __'`  — 2 wrong symbols
<details>
<summary>Error message</summary>

```
➜  ~ npx browserslist '>2% in __' 
/usr/local/lib/node_modules/browserslist/cli.js:96
      throw e
      ^

Error: Cannot find module 'caniuse-lite/data/regions/__.js'
```

</details>

<br />

`'>2% in alt-__'` — 2 wrong symbols after `alt-`
<details>
<summary>Error message</summary>

```
➜  ~ npx browserslist '>2% in alt-__'
/usr/local/lib/node_modules/browserslist/cli.js:96
      throw e
      ^

Error: Cannot find module 'caniuse-lite/data/regions/alt-__.js'
```

</details>


## My suggestions
- Wrap dynamic `require('caniuse-lite/**/*.js')` with `try { ... } catch { throw new BrowserslistError('...') }` with messages:
    - Unknown feature name `${name}`
    - Unknown region name `${name}` — for countries and continents
- Add tests

**Result**
```
➜  ~ npx browserslist '>0% in LL'
browserslist: Unknown region name `LL`.
```