### PR TITLE
Update IE 11 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ when you add the following to `package.json`:
 
 ```json
   "browserslist": [
-    "defaults",
-    "not IE 11",
+    "defaults and supports es6-module",
     "maintained node versions"
   ]
 ```
@@ -30,8 +29,7 @@ Or in `.browserslistrc` config:
 ```yaml
 # Browsers that we support
 
-defaults
-not IE 11
+defaults and supports es6-module
 maintained node versions
 ```
 
@@ -218,7 +216,7 @@ combiner even if `or` is used (this is an API implementation specificity).
 | `and` combiner <br> (intersection) | ![intersection of queries](img/intersection.svg) | `> .5% and last 2 versions` |
 | `not` combiner <br> (relative complement) | ![Relative complement of queries](img/complement.svg) | These three are equivalent to one another: <br> `> .5% and not last 2 versions` <br> `> .5% or not last 2 versions` <br> `> .5%, not last 2 versions` |
 
-_A quick way to test your query is to do `npx browserslist '> 0.5%, not IE 11'`
+_A quick way to test your query is to do `npx browserslist '> 0.3%, not IE 11'`
 in your terminal._
 
 ### Full List

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ browsers in `package.json` with `browserslist` key:
   "browserslist": [
     "last 1 version",
     "> 1%",
-    "IE 10"
+    "IE 11"
   ]
 }
 ```
@@ -381,7 +381,7 @@ Each line is combined with the `or` combiner. Comments starts with `#` symbo
 
 last 1 version
 > 1%
-IE 10 # sorry
+IE 11 # sorry
 ```
 
 Browserslist will check config in every directory in `path`.
@@ -431,7 +431,7 @@ When writing a shared Browserslist package, just export an array.
 module.exports = [
   'last 1 version',
   '> 1%',
-  'ie 10'
+  'ie 11'
 ]
 ```
 
@@ -451,7 +451,7 @@ module.exports = {
   production: [
     'last 1 version',
     '> 1%',
-    'ie 10'
+    'ie 11'
   ]
 }
 ```
@@ -470,7 +470,7 @@ In `package.json`:
   "browserslist": {
     "production": [
       "> 1%",
-      "ie 10"
+      "ie 11"
     ],
     "modern": [
       "last 1 chrome version",
@@ -487,7 +487,7 @@ In `.browserslistrc` config:
 ```ini
 [production]
 > 1%
-ie 10
+ie 11
 
 [modern]
 last 1 chrome version
@@ -552,8 +552,8 @@ function process (source, opts) {
 }
 ```
 
-Queries can be a string `"> 1%, IE 10"`
-or an array `['> 1%', 'IE 10']`.
+Queries can be a string `"> 1%, IE 11"`
+or an array `['> 1%', 'IE 11']`.
 
 If a query is missing, Browserslist will look for a config file.
 You can provide a `path` option (that can be a file) to find the config file
@@ -581,7 +581,7 @@ Options:
 For non-JS environment and debug purpose you can use CLI tool:
 
 ```sh
-browserslist "> 1%, IE 10"
+browserslist "> 1%, IE 11"
 ```
 
 You can get total users coverage for selected browsers by JS API:


### PR DESCRIPTION
Now IE 11 is in `dead` query and is not displayed in `defaults`. I suggest updating the examples for the current one README.md.

- Updated examples from the new [browsersl.ist site](https://browsersl.ist)
- Replaced example `'> 0.5%, not IE 11'` to `'> 0.3%, not IE 11'`. Current query doesn't includes IE
- Replaced `IE 10` to `IE 11`. IE10 seems to be completely outdated