### PR TITLE
Fix Android time queries with mobileToDesktop

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,6 +270,11 @@ function normalizeAndroidVersions(androidVersions, chromeVersions) {
 function normalizeAndroidData(android, chrome) {
   android.released = normalizeAndroidVersions(android.released, chrome.released)
   android.versions = normalizeAndroidVersions(android.versions, chrome.versions)
+  android.released.forEach(function (v) {
+    if (android.releaseDate[v] === undefined) {
+      android.releaseDate[v] = chrome.releaseDate[v]
+    }
+  })
   return android
 }
 

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -1,0 +1,25 @@
+const { test } = require('uvu')
+const { equal } = require('uvu/assert')
+
+delete require.cache[require.resolve('..')]
+const browserslist = require('..')
+
+const MAX_VERSIONS = Number.MAX_SAFE_INTEGER
+const MAX_YEARS = Number.MAX_SAFE_INTEGER
+
+const allTest = opts => {
+  const result = browserslist('since 1990', opts)
+  equal(browserslist('last ' + MAX_VERSIONS + ' versions', opts), result)
+  equal(browserslist('last ' + MAX_YEARS + ' years', opts), result)
+  // Removed until mobileToDesktop works for usage queries
+  // equal(browserslist('>= 0%, not unreleased versions', opts), result)
+}
+
+test('Queries for all browsers', () => {
+  allTest()
+})
+test('Queries for all browsers with mobile to desktop', () => {
+  allTest({ mobileToDesktop: true })
+})
+
+test.run()


### PR DESCRIPTION
Fixes #762.  The release dates were not being cloned along with the version data.