### PR TITLE
Fix computation of last queries for Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var parse = require('./parse')
 var env = require('./node') // Will load browser.js in webpack
 
 var YEAR = 365.259641 * 24 * 60 * 60 * 1000
-var ANDROID_EVERGREEN_FIRST = 37
+var ANDROID_EVERGREEN_FIRST = '37'
 
 // Helpers
 
@@ -258,13 +258,12 @@ function byName(name, context) {
 }
 
 function normalizeAndroidVersions(androidVersions, chromeVersions) {
-  var firstEvergreen = ANDROID_EVERGREEN_FIRST
-  var last = chromeVersions[chromeVersions.length - 1]
+  var iFirstEvergreen = chromeVersions.indexOf(ANDROID_EVERGREEN_FIRST)
   return androidVersions
     .filter(function (version) {
       return /^(?:[2-4]\.|[34]$)/.test(version)
     })
-    .concat(chromeVersions.slice(firstEvergreen - last - 1))
+    .concat(chromeVersions.slice(iFirstEvergreen))
 }
 
 function normalizeAndroidData(android, chrome) {
@@ -295,14 +294,12 @@ function unknownQuery(query) {
 
 function filterAndroid(list, versions, context) {
   if (context.mobileToDesktop) return list
-  var released = browserslist.data.android.released
-  var last = released[released.length - 1]
-  var diff = last - ANDROID_EVERGREEN_FIRST - versions
-  if (diff > 0) {
+  var released = browserslist.data.chrome.released
+  var nEvergreen = released.length - released.indexOf(ANDROID_EVERGREEN_FIRST)
+  if (versions <= nEvergreen) {
     return list.slice(-1)
-  } else {
-    return list.slice(diff - 1)
   }
+  return list.slice(nEvergreen - 1 - versions)
 }
 
 function resolve(queries, context) {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -19,9 +19,15 @@ test.before.each(() => {
       released: ['4.4', '4.4.3-4.4.4', '67'],
       versions: [],
       releaseDate: {}
+    },
+    chrome: {
+      name: 'chrome',
+      released: ['7', '17', '27', '37', '47', '57', '67'],
+      versions: [],
+      releaseDate: {}
     }
   }
-});
+})
 
 test.after.each(() => {
   browserslist.data = originData
@@ -46,13 +52,10 @@ test('has case insensitive aliases', () => {
 
 test('has special logic for android', () => {
   equal(browserslist('last 4 android versions'), ['android 67'])
-  equal(
-    browserslist('last 31 android versions'),
-    [
-      'android 67',
-      'android 4.4.3-4.4.4'
-    ]
-  )
+  equal(browserslist('last 5 android versions'), [
+    'android 67',
+    'android 4.4.3-4.4.4'
+  ])
 })
 
 test.run()

--- a/test/direct.test.js
+++ b/test/direct.test.js
@@ -58,24 +58,17 @@ test('supports Can I Use missing mobile versions', () => {
   equal(browserslist('and_ff 60', opts), ['and_ff 60'])
   equal(browserslist('ie_mob 9', opts), ['ie_mob 9'])
   equal(browserslist('op_mob 30', opts), ['op_mob 30'])
-  equal(
-    browserslist('chromeandroid >= 52 and chromeandroid < 54', opts),
-    ['and_chr 53', 'and_chr 52']
-  )
-  equal(
-    browserslist('and_chr 52-53', opts),
-    ['and_chr 53', 'and_chr 52']
-  )
-  equal(
-    browserslist('android 4.4-38', opts),
-    [
-      'android 38',
-      'android 37',
-      'android 36',
-      'android 4.4.3-4.4.4',
-      'android 4.4'
-    ]
-  )
+  equal(browserslist('chromeandroid >= 52 and chromeandroid < 54', opts), [
+    'and_chr 53',
+    'and_chr 52'
+  ])
+  equal(browserslist('and_chr 52-53', opts), ['and_chr 53', 'and_chr 52'])
+  equal(browserslist('android 4.4-38', opts), [
+    'android 38',
+    'android 37',
+    'android 4.4.3-4.4.4',
+    'android 4.4'
+  ])
 })
 
 test('missing mobile versions are not aliased by default', () => {
@@ -88,7 +81,7 @@ test('missing mobile versions are not aliased by default', () => {
 test('works for all browsers', () => {
   not.throws(() => {
     let first = browserslist(['> 0%', 'dead'])
-    browserslist(first, {mobileToDesktop: true})
+    browserslist(first, { mobileToDesktop: true })
   })
 })
 

--- a/test/last.test.js
+++ b/test/last.test.js
@@ -22,8 +22,8 @@ test.before.each(() => {
     },
     chrome: {
       name: 'chrome',
-      released: ['37', '38', '39'],
-      versions: ['37', '38', '39', '40'],
+      released: ['36', '37', '38', '39'],
+      versions: ['36', '37', '38', '39', '40'],
       releaseDate: {}
     },
     bb: {
@@ -40,7 +40,7 @@ test.before.each(() => {
     },
     android: {
       name: 'android',
-      released: ['4.4', '4.4.3-4.4.4', '67'],
+      released: ['4.4', '4.4.3-4.4.4', '39'],
       versions: [],
       releaseDate: {}
     },
@@ -60,92 +60,78 @@ test.after.each(() => {
 test('selects versions of each browser', () => {
   let res = browserslist('last 2 versions', undefined, true)
 
-  equal(
-    res,
-    [
-      'android 67',
-      'bb 8',
-      'chrome 39',
-      'chrome 38',
-      'edge 12',
-      'ie 11',
-      'ie 10',
-      'opera 86',
-      'opera 85'
-    ]
-  )
+  equal(res, [
+    'android 39',
+    'bb 8',
+    'chrome 39',
+    'chrome 38',
+    'edge 12',
+    'ie 11',
+    'ie 10',
+    'opera 86',
+    'opera 85'
+  ])
 })
 
 test('has special logic for android', () => {
-  equal(
-    browserslist('last 31 versions'),
-    [
-      'android 67',
-      'android 4.4.3-4.4.4',
-      'bb 8',
-      'chrome 39',
-      'chrome 38',
-      'chrome 37',
-      'edge 12',
-      'ie 11',
-      'ie 10',
-      'ie 9',
-      'opera 86',
-      'opera 85'
-    ]
-  )
+  equal(browserslist('last 4 versions'), [
+    'android 39',
+    'android 4.4.3-4.4.4',
+    'bb 8',
+    'chrome 39',
+    'chrome 38',
+    'chrome 37',
+    'chrome 36',
+    'edge 12',
+    'ie 11',
+    'ie 10',
+    'ie 9',
+    'opera 86',
+    'opera 85'
+  ])
 })
 
 test('supports pluralization', () => {
-  equal(
-    browserslist('last 1 version'),
-      [
-      'android 67',
-      'bb 8',
-      'chrome 39',
-      'edge 12',
-      'ie 11',
-      'opera 86'
-    ]
-  )
+  equal(browserslist('last 1 version'), [
+    'android 39',
+    'bb 8',
+    'chrome 39',
+    'edge 12',
+    'ie 11',
+    'opera 86'
+  ])
 })
 
 test('is case insensitive', () => {
-  equal(
-    browserslist('Last 01 Version'),
-    [
-      'android 67',
-      'bb 8',
-      'chrome 39',
-      'edge 12',
-      'ie 11',
-      'opera 86'
-    ]
-  )
+  equal(browserslist('Last 01 Version'), [
+    'android 39',
+    'bb 8',
+    'chrome 39',
+    'edge 12',
+    'ie 11',
+    'opera 86'
+  ])
 })
 
 test('excludes unreleased versions if enabling mobile to desktop', () => {
-  equal(
-    browserslist('last 2 versions', { mobileToDesktop: true }),
-    [
-      'and_chr 39',
-      'and_chr 38',
-      'android 39',
-      'android 38',
-      'bb 8',
-      'chrome 39',
-      'chrome 38',
-      'edge 12',
-      'ie 11',
-      'ie 10',
-      'ie_mob 11',
-      'ie_mob 10',
-      'op_mob 86',
-      'op_mob 85',
-      'opera 86',
-      'opera 85'
-    ]
-  )
+  equal(browserslist('last 2 versions', { mobileToDesktop: true }), [
+    'and_chr 39',
+    'and_chr 38',
+    'android 39',
+    'android 38',
+    'bb 8',
+    'chrome 39',
+    'chrome 38',
+    'edge 12',
+    'ie 11',
+    'ie 10',
+    'ie_mob 11',
+    'ie_mob 10',
+    'op_mob 86',
+    'op_mob 85',
+    'opera 86',
+    'opera 85'
+  ])
 })
 
 test.run()


### PR DESCRIPTION
Fixes #764 by directly finding the correct array index.  This simply assumes that Chrome 37 exists and that the latest release of Chrome equals that of Android, rather than assuming anything about the version history.

A few tests failed after the change, but they are all flawed.  After adjusting, I think there is good coverage.

Note Prettier made a few extra changes so you might want to turn off white space on the diffs.