### PR TITLE
Fix feature support queries with mobileToDesktop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -124,7 +124,9 @@ declare namespace browserslist {
 
   let cache: {
     [feature: string]: {
-      [name: string]: 'y' | 'n'
+      [name: string]: {
+        [version: string]: string
+      }
     }
   }
 

--- a/node.js
+++ b/node.js
@@ -272,8 +272,9 @@ module.exports = {
     var stats = feature(compressed).stats
     features[name] = {}
     for (var i in stats) {
+      features[name][i] = {}
       for (var j in stats[i]) {
-        features[name][i + ' ' + j] = stats[i][j]
+        features[name][i][j] = stats[i][j]
       }
     }
   },

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -4,50 +4,105 @@ let { equal, is, throws } = require('uvu/assert')
 delete require.cache[require.resolve('..')]
 let browserslist = require('..')
 
-let originCache = browserslist.cache
+let originData = { ...browserslist.data }
 
 test.before.each(() => {
-  browserslist.cache = {}
-  browserslist.data.and_chr = {
-    name: 'and_chr',
-    versions: ['81'],
-    released: [],
-    releaseDate: {}
+  browserslist.data = {
+    and_chr: {
+      name: 'and_chr',
+      versions: ['81'],
+      released: ['81'],
+      releaseDate: {}
+    },
+    chrome: {
+      name: 'chrome',
+      versions: ['80', '81', '82'],
+      released: ['80', '81'],
+      releaseDate: {}
+    },
+    ie: {
+      name: 'ie',
+      versions: ['10', '11'],
+      released: ['10', '11'],
+      releaseDate: {}
+    }
   }
 })
 
 test.after.each(() => {
-  browserslist.cache = originCache
+  browserslist.clearCaches()
+  browserslist.data = originData
 })
 
 test('load features from Can I Use', () => {
+  browserslist.data = originData
   is(browserslist('supports objectrtc').length > 0, true)
 })
 
 test('throw an error on wrong feature name from Can I Use', () => {
-  throws(() => browserslist('supports wrong-feature-name'), /Unknown feature name/)
+  throws(
+    () => browserslist('supports wrong-feature-name'),
+    /Unknown feature name/
+  )
 })
 
 test('selects browsers by feature', () => {
-  browserslist.cache = {
-    rtcpeerconnection: {
-      'and_chr 81': 'y',
-      'firefox 2': 'n'
-    }
+  browserslist.cache.rtcpeerconnection = {
+    and_chr: { 81: 'y' },
+    chrome: { 80: 'n', 81: 'y', 82: 'y' },
+    ie: { 10: 'n', 11: 'n' }
   }
 
-  equal(browserslist('supports rtcpeerconnection'), ['and_chr 81'])
+  equal(browserslist('supports rtcpeerconnection'), [
+    'and_chr 81',
+    'chrome 82',
+    'chrome 81'
+  ])
 })
 
 test('selects browsers by feature with dashes in its name', () => {
-  browserslist.cache = {
-    'arrow-functions': {
-      'and_chr 81': 'y',
-      'ie 11': 'n'
-    }
+  browserslist.cache['arrow-functions'] = {
+    and_chr: { 81: 'n' },
+    chrome: { 80: 'n', 81: 'y', 82: 'y' },
+    ie: { 10: 'n', 11: 'y' }
   }
 
-  equal(browserslist('supports arrow-functions'), ['and_chr 81'])
+  equal(browserslist('supports arrow-functions'), [
+    'chrome 82',
+    'chrome 81',
+    'ie 11'
+  ])
+})
+
+test('Selects extra versions with mobile to desktop option', () => {
+  browserslist.cache.filesystem = {
+    and_chr: { 81: 'y' },
+    chrome: { 80: 'y', 81: 'y', 82: 'y' },
+    ie: { 10: 'n', 11: 'n' }
+  }
+
+  equal(browserslist('supports filesystem', { mobileToDesktop: true }), [
+    'and_chr 82',
+    'and_chr 81',
+    'and_chr 80',
+    'chrome 82',
+    'chrome 81',
+    'chrome 80'
+  ])
+})
+
+test('Ignores mobile to desktop if unsupported by latest', () => {
+  browserslist.cache['font-smooth'] = {
+    and_chr: { 81: 'n' },
+    chrome: { 80: 'y', 81: 'y', 82: 'y' },
+    ie: { 10: 'n', 11: 'n' }
+  }
+
+  equal(browserslist('supports font-smooth', { mobileToDesktop: true }), [
+    'chrome 82',
+    'chrome 81',
+    'chrome 80'
+  ])
 })
 
 test.run()


### PR DESCRIPTION
Fixes #761 by adding support for `mobileToDesktop` to feature queries.

- Changed the feature cache to a 2 dimensional object for each browser and version to make the implementation much simpler
- Uses existing function to get the mobile to desktop data
- Only looks to the desktop version's support data when (a) there is no mobile data and (b) the feature is supported by the latest mobile version
- Added a couple specific mobile to desktop tests and made the others more specific for the common data

Note the way the existing tests were messing with the `cache` property doesn't really work.  This is evident if you just try to use the same feature from one test to the next (the first cache setting is always used).  I didn't bother to try to make it work because I think it would involve exporting the cache itself, so I just removed some of that and use a different feature for each test.
