### PR TITLE
use exact version to have reproducible builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "unit": "NODE_ENV=test uvu test .test.js"
   },
   "dependencies": {
-    "caniuse-lite": "^1.0.30001503",
+    "caniuse-lite": "1.0.30001503",
     "electron-to-chromium": "^1.4.431",
     "node-releases": "^2.0.12",
     "update-browserslist-db": "^1.0.11"


### PR DESCRIPTION
when checking out an old browserslist version - e.g from 2020 - and running browserslist("last 2 chrome versions") it prints now the browser versions from 2020 not from 2023.