### PR TITLE
Add `fully supports` and `partially supports` queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ when you add the following to `package.json`:
 
 ```json
   "browserslist": [
-    "defaults and partially supports es6-module",
+    "defaults and fully supports es6-module",
     "maintained node versions"
   ]
 ```
@@ -29,7 +29,7 @@ Or in `.browserslistrc` config:
 ```yaml
 # Browsers that we support
 
-defaults and partially supports es6-module
+defaults and fully supports es6-module
 maintained node versions
 ```
 
@@ -273,18 +273,20 @@ You can specify the browser and Node.js versions by queries (case insensitive):
     to PhantomJS runtime.
 * `extends browserslist-config-mycompany`: take queries from
   `browserslist-config-mycompany` npm package.
-* `fully supports es6-module`: browsers with full support for specific features.
-  `es6-module` here is the `feat` parameter at the URL of the [Can I Use]
-  page. For example `fully supports css-grid` will omit Edge 12-15, as those browser versions are marked as [having partial support].
-  A list of all available features can be found at [`caniuse-lite/data/features`].
-* `partially supports es6-module`: browsers with full or partial support for specific features.
-  `es6-module` here is the `feat` parameter at the URL of the [Can I Use]
-  page. For example `fully supports css-grid` will include Edge 12-15 support, as those browser versions are marked as [having partial support].
-  A list of all available features can be found at [`caniuse-lite/data/features`].
-* `supports es6-module`: browsers with full or partial support for specific features. An alias for `partially supports es6-module`.
+* By browser support:<br>
+  In these example queries `es6` and `es6-module` are the the `feat` parameter
+  from the URL of the [Can I Use] page. A list of all available features can be
+  found at [`caniuse-lite/data/features`].
+  * `fully supports es6`: browsers with full support for specific
+    features. For example `fully supports css-grid` will omit Edge 12-15, as
+    those browser versions are marked as [having partial support].
+  * `partially supports es6-module` or `supports es6-module`:  browsers with
+    full or partial support for specific features. For example
+    `partially supports css-grid` will include Edge 12-15 support, as those
+    browser versions are marked as [having partial support].
 * `browserslist config`: the browsers defined in Browserslist config. Useful
   in Differential Serving to modify user’s config like
-  `browserslist config and partially supports es6-module`.
+  `browserslist config and fully supports es6-module`.
 * `since 2015` or `last 2 years`: all versions released since year 2015
   (also `since 2015-03` and `since 2015-03-10`).
 * `unreleased versions` or `unreleased Chrome versions`:
@@ -300,7 +302,7 @@ You can add `not ` to any query.
 [still maintained]:            https://github.com/nodejs/Release
 [Can I Use]:                   https://caniuse.com/
 [Firefox Extended Support Release]: https://support.mozilla.org/en-US/kb/choosing-firefox-update-channel
-[having partial support]: https://caniuse.com/css-grid)
+[having partial support]: https://caniuse.com/css-grid
 
 ### Grammar Definition
 

--- a/README.md
+++ b/README.md
@@ -275,8 +275,12 @@ You can specify the browser and Node.js versions by queries (case insensitive):
   `browserslist-config-mycompany` npm package.
 * `supports es6-module`: browsers with support for specific features.
   `es6-module` here is the `feat` parameter at the URL of the [Can I Use]
-  page. A list of all available features can be found at
-  [`caniuse-lite/data/features`].
+  page. This includes browsers with full or partial support for a feature.
+  A list of all available features can be found at [`caniuse-lite/data/features`].
+* `fully supports es6-module`: browsers with support for specific features.
+  `es6-module` here is the `feat` parameter at the URL of the [Can I Use]
+  page. This only includes browsers with full support for a feature.
+  A list of all available features can be found at [`caniuse-lite/data/features`].
 * `browserslist config`: the browsers defined in Browserslist config. Useful
   in Differential Serving to modify user’s config like
   `browserslist config and supports es6-module`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ when you add the following to `package.json`:
 
 ```json
   "browserslist": [
-    "defaults and supports es6-module",
+    "defaults and partially supports es6-module",
     "maintained node versions"
   ]
 ```
@@ -29,7 +29,7 @@ Or in `.browserslistrc` config:
 ```yaml
 # Browsers that we support
 
-defaults and supports es6-module
+defaults and partially supports es6-module
 maintained node versions
 ```
 
@@ -273,17 +273,18 @@ You can specify the browser and Node.js versions by queries (case insensitive):
     to PhantomJS runtime.
 * `extends browserslist-config-mycompany`: take queries from
   `browserslist-config-mycompany` npm package.
-* `supports es6-module`: browsers with support for specific features.
+* `fully supports es6-module`: browsers with full support for specific features.
   `es6-module` here is the `feat` parameter at the URL of the [Can I Use]
-  page. This includes browsers with full or partial support for a feature.
+  page. For example `fully supports css-grid` will omit Edge 12-15, as those browser versions are marked as [having partial support].
   A list of all available features can be found at [`caniuse-lite/data/features`].
-* `fully supports es6-module`: browsers with support for specific features.
+* `partially supports es6-module`: browsers with full or partial support for specific features.
   `es6-module` here is the `feat` parameter at the URL of the [Can I Use]
-  page. This only includes browsers with full support for a feature.
+  page. For example `fully supports css-grid` will include Edge 12-15 support, as those browser versions are marked as [having partial support].
   A list of all available features can be found at [`caniuse-lite/data/features`].
+* `supports es6-module`: browsers with full or partial support for specific features. An alias for `partially supports es6-module`.
 * `browserslist config`: the browsers defined in Browserslist config. Useful
   in Differential Serving to modify user’s config like
-  `browserslist config and supports es6-module`.
+  `browserslist config and partially supports es6-module`.
 * `since 2015` or `last 2 years`: all versions released since year 2015
   (also `since 2015-03` and `since 2015-03-10`).
 * `unreleased versions` or `unreleased Chrome versions`:
@@ -299,6 +300,7 @@ You can add `not ` to any query.
 [still maintained]:            https://github.com/nodejs/Release
 [Can I Use]:                   https://caniuse.com/
 [Firefox Extended Support Release]: https://support.mozilla.org/en-US/kb/choosing-firefox-update-channel
+[having partial support]: https://caniuse.com/css-grid)
 
 ### Grammar Definition
 

--- a/index.js
+++ b/index.js
@@ -883,11 +883,11 @@ var QUERIES = {
     select: coverQuery
   },
   supports: {
-    matches: ['fullSupport', 'feature'],
-    regexp: /^(fully )?supports\s+([\w-]+)$/,
+    matches: ['supportType', 'feature'],
+    regexp: /^((?:fully|partially) )?supports\s+([\w-]+)$/,
     select: function (context, node) {
       env.loadFeature(browserslist.cache, node.feature)
-      var includePartialSupport = !node.fullSupport;
+      var includePartialSupport = (node.supportType || '').trim() !== 'fully';
       var features = browserslist.cache[node.feature]
       var result = []
       for (var name in features) {

--- a/index.js
+++ b/index.js
@@ -884,10 +884,10 @@ var QUERIES = {
   },
   supports: {
     matches: ['supportType', 'feature'],
-    regexp: /^((?:fully|partially) )?supports\s+([\w-]+)$/,
+    regexp: /^(?:(fully|partially) )?supports\s+([\w-]+)$/,
     select: function (context, node) {
       env.loadFeature(browserslist.cache, node.feature)
-      var includePartialSupport = (node.supportType || '').trim() !== 'fully';
+      var includePartialSupport = (node.supportType || 'partially') === 'partially';
       var features = browserslist.cache[node.feature]
       var result = []
       for (var name in features) {

--- a/index.js
+++ b/index.js
@@ -298,10 +298,10 @@ function filterJumps(list, name, nVersions, context) {
   return list.slice(jump - 1 - nVersions)
 }
 
-function isSupported(flags) {
+function isSupported(flags, includePartialSupport) {
   return (
     typeof flags === 'string' &&
-    (flags.indexOf('y') >= 0 || flags.indexOf('a') >= 0)
+    (flags.indexOf('y') >= 0 || (includePartialSupport && flags.indexOf('a') >= 0))
   )
 }
 
@@ -883,10 +883,11 @@ var QUERIES = {
     select: coverQuery
   },
   supports: {
-    matches: ['feature'],
-    regexp: /^supports\s+([\w-]+)$/,
+    matches: ['fullSupport', 'feature'],
+    regexp: /^(fully )?supports\s+([\w-]+)$/,
     select: function (context, node) {
       env.loadFeature(browserslist.cache, node.feature)
+      var includePartialSupport = !node.fullSupport;
       var features = browserslist.cache[node.feature]
       var result = []
       for (var name in features) {
@@ -895,13 +896,13 @@ var QUERIES = {
         var checkDesktop =
           context.mobileToDesktop &&
           name in browserslist.desktopNames &&
-          isSupported(features[name][data.released.slice(-1)[0]])
+          isSupported(features[name][data.released.slice(-1)[0]], includePartialSupport)
         data.versions.forEach(function (version) {
           var flags = features[name][version]
           if (flags === undefined && checkDesktop) {
             flags = features[browserslist.desktopNames[name]][version]
           }
-          if (isSupported(flags)) {
+          if (isSupported(flags, includePartialSupport)) {
             result.push(name + ' ' + version)
           }
         })

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -60,7 +60,21 @@ test('selects browsers by feature, including partial support by default', () => 
   ])
 })
 
-test('selects browsers by feature, omiting partial support in in strict mode', () => {
+test('selects browsers by feature, including partial support in partial mode', () => {
+  browserslist.cache.rtcpeerconnection = {
+    and_chr: { 81: 'y' },
+    chrome: { 80: 'n', 81: 'a', 82: 'y' },
+    ie: { 10: 'n', 11: 'n' }
+  }
+
+  equal(browserslist('partially supports rtcpeerconnection'), [
+    'and_chr 81',
+    'chrome 82',
+    'chrome 81'
+  ])
+})
+
+test('selects browsers by feature, omiting partial support in full mode', () => {
   browserslist.cache.rtcpeerconnection = {
     and_chr: { 81: 'y' },
     chrome: { 80: 'n', 81: 'a', 82: 'y' },

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -46,10 +46,10 @@ test('throw an error on wrong feature name from Can I Use', () => {
   )
 })
 
-test('selects browsers by feature', () => {
+test('selects browsers by feature, including partial support by default', () => {
   browserslist.cache.rtcpeerconnection = {
     and_chr: { 81: 'y' },
-    chrome: { 80: 'n', 81: 'y', 82: 'y' },
+    chrome: { 80: 'n', 81: 'a', 82: 'y' },
     ie: { 10: 'n', 11: 'n' }
   }
 
@@ -59,6 +59,20 @@ test('selects browsers by feature', () => {
     'chrome 81'
   ])
 })
+
+test('selects browsers by feature, omiting partial support in in strict mode', () => {
+  browserslist.cache.rtcpeerconnection = {
+    and_chr: { 81: 'y' },
+    chrome: { 80: 'n', 81: 'a', 82: 'y' },
+    ie: { 10: 'n', 11: 'n' }
+  }
+
+  equal(browserslist('fully supports rtcpeerconnection'), [
+    'and_chr 81',
+    'chrome 82',
+  ])
+})
+
 
 test('selects browsers by feature with dashes in its name', () => {
   browserslist.cache['arrow-functions'] = {


### PR DESCRIPTION
### Context 

Caniuse features can be marked as "fully supported", "partially supported" and a few other values that aren't relevant to this reminder/primer (see the [stats key in caniuse docs](https://github.com/Fyrd/caniuse/blob/main/CONTRIBUTING.md#supported-changes)). For instance for the [`es6`](https://caniuse.com/es6) feature, partial support began with Chrome 21 but wasn't marked as fully supported till Chrome 51.

Browserslist's `supports` query includes browsers with both full and partial support for a given feature. Thus `supports es6` includes Chrome 21 and up. This is somewhat surprising to me as if you'd try to use es6 features in Chrome 21 things would go very wrong very quickly. I hope to think of browserslist's supports query as "this is a baseline from which you can assume full support for a feature, so stuff like babel won't need to transpile/polyfill this at all", but thanks to it's partial support that's not quite what it does.


I'd like a way to make a supports query that only considers full support, instead of partial and full support. I appreciate that changing the behaviour of supports after so long would be an unexpected change to the point of it being a breaking change and so a new query would be needed.

This PR is an approach to solve that problem, but I'd love some feedback on naming.

### This PR

This PR adds a `fully supports` query, that acts like `supports` except it only considers full browser support. As a result `fully supports es6`'s first Chrome version is Chrome 51. 

I'm not super tied to the `fully supports` name and it feels a bit clunky. In an ideal world it'd feel nicer for `supports` to be for full support, and then we have a modifier if we want to include partial support, but I know that's almost certainly too disruptive to ship. I would welcome suggestions for any syntax that you'd prefer.

One alternative is having `supports es6 fully` - where fully is a modifier of the existing supports query, kinda like how you can do `>5%` and `>5% in US`.

Another alternative is betting on this prefix more, and adding `partially supports` as a query too (with the same behaviour as `supports` currently and pushing people to use `fully supports` and `partially supports` instead of `supports`. This kinda leans into the magical future world where we could change the default behaviour of `supports` to be "full support", and then people have to opt in if they want to include partial support.
