### PR TITLE
Update Firefox ESR versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1002,7 +1002,7 @@ var QUERIES = {
     matches: [],
     regexp: /^(firefox|ff|fx)\s+esr$/i,
     select: function () {
-      return ['firefox 102', 'firefox 115']
+      return ['firefox 115']
     }
   },
   opera_mini_all: {


### PR DESCRIPTION
Firefox ESR seems to be at 115 since the release of Firefox 118 on September 26th.