### PR TITLE
fix: clone releaseDate when normalizing android

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,6 +252,7 @@ function normalizeAndroidVersions(androidVersions, chromeVersions) {
 function normalizeAndroidData(android, chrome) {
   android.released = normalizeAndroidVersions(android.released, chrome.released)
   android.versions = normalizeAndroidVersions(android.versions, chrome.versions)
+  android.releaseDate = Object.assign({}, android.releaseDate)
   android.released.forEach(function (v) {
     if (android.releaseDate[v] === undefined) {
       android.releaseDate[v] = chrome.releaseDate[v]


### PR DESCRIPTION
Fixes #804.

When using `mobileToDesktop` option, the `android` data is being mutated. In order to prevent this `releaseDate` needs to be cloned.