### PR TITLE
Allow arbitrary whitespaces in `supports` queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -893,7 +893,7 @@ var QUERIES = {
   },
   supports: {
     matches: ['supportType', 'feature'],
-    regexp: /^(?:(fully|partially) )?supports\s+([\w-]+)$/,
+    regexp: /^(?:(fully|partially)\s+)?supports\s+([\w-]+)$/,
     select: function (context, node) {
       env.loadFeature(browserslist.cache, node.feature)
       var withPartial = node.supportType !== 'fully'

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -72,6 +72,12 @@ test('selects browsers by feature, including partial support', () => {
     'chrome 82',
     'chrome 81'
   ])
+
+  equal(browserslist('partially     supports rtcpeerconnection'), [
+    'and_chr 81',
+    'chrome 82',
+    'chrome 81'
+  ])
 })
 
 test('selects browsers by feature, omiting partial support', () => {
@@ -82,6 +88,11 @@ test('selects browsers by feature, omiting partial support', () => {
   }
 
   equal(browserslist('fully supports rtcpeerconnection'), [
+    'and_chr 81',
+    'chrome 82'
+  ])
+
+  equal(browserslist('fully    supports rtcpeerconnection'), [
     'and_chr 81',
     'chrome 82'
   ])


### PR DESCRIPTION
Allow queries like:

- `partially          supports rtcpeerconnection`
- `fully          supports rtcpeerconnection`