### PR TITLE
Introduce `browserslist.findConfigFile` API

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -44,6 +44,8 @@ module.exports = {
 
   findConfig: noop,
 
+  findConfigFile: noop,
+
   clearCaches: noop,
 
   oldDataWarning: noop,

--- a/index.d.ts
+++ b/index.d.ts
@@ -174,6 +174,8 @@ declare namespace browserslist {
 
   function findConfig(...pathSegments: string[]): Config | undefined
 
+  function findConfigFile(...pathSegments: string[]): string | undefined
+
   interface LoadConfigOptions {
     config?: string
     path?: string

--- a/index.js
+++ b/index.js
@@ -491,6 +491,7 @@ browserslist.versionAliases = {}
 browserslist.clearCaches = env.clearCaches
 browserslist.parseConfig = env.parseConfig
 browserslist.readConfig = env.readConfig
+browserslist.findConfigFile = env.findConfigFile
 browserslist.findConfig = env.findConfig
 browserslist.loadConfig = env.loadConfig
 

--- a/node.js
+++ b/node.js
@@ -126,6 +126,14 @@ function parsePackage(file) {
   return list
 }
 
+function parsePackageOrReadConfig(file) {
+  if (path.basename(file) === "package.json") {
+    return parsePackage(file)
+  } else {
+    return module.exports.readConfig(file)
+  }
+}
+
 function latestReleaseTime(agents) {
   var latest = 0
   for (var name in agents) {
@@ -237,11 +245,7 @@ module.exports = {
       return process.env.BROWSERSLIST
     } else if (opts.config || process.env.BROWSERSLIST_CONFIG) {
       var file = opts.config || process.env.BROWSERSLIST_CONFIG
-      if (path.basename(file) === 'package.json') {
-        return pickEnv(parsePackage(file), opts)
-      } else {
-        return pickEnv(module.exports.readConfig(file), opts)
-      }
+      return pickEnv(parsePackageOrReadConfig(file), opts)
     } else if (opts.path) {
       return pickEnv(module.exports.findConfig(opts.path), opts)
     } else {
@@ -383,10 +387,7 @@ module.exports = {
     var resolved
     var configFile = this.findConfigFile(from)
     if (configFile) {
-      resolved = path.basename(configFile) === "package.json"
-        ? parsePackage(configFile)
-        : module.exports.readConfig(configFile)
-
+      resolved = parsePackageOrReadConfig(configFile)
     }
 
     if (!process.env.BROWSERSLIST_DISABLE_CACHE) {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -78,16 +78,32 @@ test('returns undefined on no config', () => {
   equal(browserslist.findConfig(__dirname), undefined)
 })
 
+test('findConfigFile returns undefined on no config', () => {
+  equal(browserslist.findConfigFile(__dirname), undefined)
+})
+
 test('reads config', () => {
   equal(browserslist.findConfig(FILE), { defaults: ['ie 11', 'ie 10'] })
+})
+
+test('findConfigFile returns browserslist', () => {
+  equal(browserslist.findConfigFile(FILE), join(__dirname, 'fixtures', 'browserslist'))
 })
 
 test('reads .browserslistrc config', () => {
   equal(browserslist.findConfig(RC), { defaults: ['ie 11'] })
 })
 
+test('findConfigFile returns .browserslistrc config', () => {
+  equal(browserslist.findConfigFile(RC), join(__dirname, 'fixtures', 'rc', '.browserslistrc'))
+})
+
 test('reads config from package.json', () => {
   equal(browserslist.findConfig(PACKAGE), { defaults: ['ie 9', 'ie 10'] })
+})
+
+test('findConfigFile returns package.json', () => {
+  equal(browserslist.findConfigFile(PACKAGE), join(__dirname, 'fixtures', 'package', 'package.json'))
 })
 
 test('shows warning on broken package.json', () => {


### PR DESCRIPTION
In this PR we introduce a new API `findConfigFile` that returns the absolute path of the loaded browserslist config: one of `package.json`, `.browserslistrc` or `browserslist`.

The motivation of this PR is to pass `@babel/preset-env` the loaded browserslist config files, so that the env preset can then call the Babel plugin `api.addDependency` to have other tools (such as `babel-loader` and `@rollup/plugin-babel`) to recognize the browserslist config as a build dependency.

See also https://github.com/babel/babel-loader/issues/690