### PR TITLE
Display time since the last update of caniuse-lite

### DIFF
--- a/node.js
+++ b/node.js
@@ -416,13 +416,13 @@ module.exports = {
     if (process.env.BROWSERSLIST_IGNORE_OLD_DATA) return
 
     var latest = latestReleaseTime(agentsObj)
-    var halfYearAgo = Date.now() - TIME_TO_UPDATE_CANIUSE
+    var currentTime = Date.now()
 
-    if (latest !== 0 && latest < halfYearAgo) {
+    if (latest !== 0 && latest < currentTime - TIME_TO_UPDATE_CANIUSE) {
       var monthsOld = Math.floor(
-        (Date.now() - latest) / (1000 * 60 * 60 * 24 * 30)
+        (currentTime - latest) / (1000 * 60 * 60 * 24 * 30)
       )
-      
+
       console.warn(
         'Browserslist: caniuse-lite is ' +
           monthsOld +

--- a/node.js
+++ b/node.js
@@ -419,11 +419,18 @@ module.exports = {
     var halfYearAgo = Date.now() - TIME_TO_UPDATE_CANIUSE
 
     if (latest !== 0 && latest < halfYearAgo) {
+      var monthsOld = Math.floor(
+        (Date.now() - latest) / (1000 * 60 * 60 * 24 * 30)
+      )
+      
       console.warn(
-        'Browserslist: caniuse-lite is outdated. Please run:\n' +
+        'Browserslist: caniuse-lite is ' +
+          monthsOld +
+          ' month' +
+          (monthsOld > 1 ? 's' : '') +
+          ' old. Time to run:\n' +
           '  npx update-browserslist-db@latest\n' +
-          '  Why you should do it regularly: ' +
-          'https://github.com/browserslist/update-db#readme'
+          '  Why you should do it regularly: https://github.com/browserslist/update-db#readme'
       )
     }
   },

--- a/node.js
+++ b/node.js
@@ -416,13 +416,11 @@ module.exports = {
     if (process.env.BROWSERSLIST_IGNORE_OLD_DATA) return
 
     var latest = latestReleaseTime(agentsObj)
-    var currentTime = Date.now()
+    var monthsOld = Math.floor(
+      (Date.now() - latest) / (1000 * 60 * 60 * 24 * 30)
+    )
 
-    if (latest !== 0 && latest < currentTime - TIME_TO_UPDATE_CANIUSE) {
-      var monthsOld = Math.floor(
-        (currentTime - latest) / (1000 * 60 * 60 * 24 * 30)
-      )
-
+    if (latest !== 0 && monthsOld > 6) {
       console.warn(
         'Browserslist: caniuse-lite is ' +
           monthsOld +

--- a/node.js
+++ b/node.js
@@ -8,7 +8,6 @@ var BrowserslistError = require('./error')
 var IS_SECTION = /^\s*\[(.+)]\s*$/
 var CONFIG_PATTERN = /^browserslist-config-/
 var SCOPED_CONFIG__PATTERN = /@[^/]+(?:\/[^/]+)?\/browserslist-config(?:-|$|\/)/
-var TIME_TO_UPDATE_CANIUSE = 6 * 30 * 24 * 60 * 60 * 1000
 var FORMAT =
   'Browserslist config should be a string or an array ' +
   'of strings with browser queries'

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -112,12 +112,16 @@ test('shows warning', () => {
   spyOn(fs, 'existsSync', findPackage)
   spyOn(fs, 'statSync', mockStatSync)
   browserslist('last 2 versions')
+  var monthsOld = 7
   equal(warn.calls, [
     [
-      'Browserslist: caniuse-lite is outdated. Please run:\n' +
+      'Browserslist: caniuse-lite is ' +
+        monthsOld +
+        ' month' +
+        (monthsOld > 1 ? 's' : '') +
+        ' old. Time to run:\n' +
         '  npx update-browserslist-db@latest\n' +
-        '  Why you should do it regularly: ' +
-        'https://github.com/browserslist/update-db#readme'
+        '  Why you should do it regularly: https://github.com/browserslist/update-db#readme'
     ]
   ])
 })


### PR DESCRIPTION
The PR request specifies a warning message for outdated caniuse-lite data, detailing the exact time since the last update

Changes:
- Implemented a warning that notifies users when caniuse-lite is outdated
- The warning now specifies the time (in months) since the last browser release related to the data
- Updated the relevant tests to verify the new functionality