### PR TITLE
Update Firefox ESR versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1021,7 +1021,7 @@ var QUERIES = {
     matches: [],
     regexp: /^(firefox|ff|fx)\s+esr$/i,
     select: function () {
-      return ['firefox 115', 'firefox 128']
+      return ['firefox 128']
     }
   },
   opera_mini_all: {


### PR DESCRIPTION
This PR updates the Firefox ESR specifier, to include only Firefox 128.

The current Firefox ESR seems a bit convoluted: Firefox 128 is supposed to be the only version, but Firefox 115 has been kept specifically for Windows 7-8.1 and macOS 10.12-10.14:

> We decided to extend support for ESR 115 only on Windows 7-8.1 and macOS 10.12-10.14 up to March 2025.
We will re-evaluate this decision in early 2025 and announce any updates on ESR 115's end-of-life then.

Relevant links:
- [Firefox ESR version page](https://whattrainisitnow.com/release/?version=esr), with the above quote
- [Firefox release train, with similar notes](https://whattrainisitnow.com/calendar/)

To be honest, I am not sure if this PR makes sense. Has browserslist run into similar situations before? Is there a way to encode the ESR version only for a given platform, or would it keep resolving Firefox 115 for ESR queries, until it is removed everywhere?

Please let me know if there is any other information that I can provide, and I will get back to you.
