### PR TITLE
Remove path from cache key for path-independent queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,12 +401,17 @@ function browserslist(queries, opts) {
   queries = prepareQueries(queries, opts)
   checkQueries(queries)
 
+  var needsPath = parse(QUERIES, queries).some(function (node) {
+    return QUERIES[node.type].needsPath
+  })
   var context = {
     ignoreUnknownVersions: opts.ignoreUnknownVersions,
     dangerousExtend: opts.dangerousExtend,
     mobileToDesktop: opts.mobileToDesktop,
-    path: opts.path,
     env: opts.env
+  }
+  if (needsPath) {
+    context.path = opts.path
   }
 
   env.oldDataWarning(browserslist.data)
@@ -1133,6 +1138,7 @@ var QUERIES = {
   browserslist_config: {
     matches: [],
     regexp: /^browserslist config$/i,
+    needsPath: true,
     select: function (context) {
       return browserslist(undefined, context)
     }
@@ -1140,6 +1146,7 @@ var QUERIES = {
   extends: {
     matches: ['config'],
     regexp: /^extends (.+)$/i,
+    needsPath: true,
     select: function (context, node) {
       return resolve(env.loadQueries(context, node.config), context)
     }

--- a/index.js
+++ b/index.js
@@ -411,6 +411,7 @@ function browserslist(queries, opts) {
     mobileToDesktop: opts.mobileToDesktop,
     env: opts.env
   }
+  // Removing to avoid using context.path without marking query as needsPath
   if (needsPath) {
     context.path = opts.path
   }


### PR DESCRIPTION
fixes #860

Strawman: remove `path` from `context` / `cacheKey` when no `QUERIES` depend on path. `hasPathAwareQueries` checks for `browserslist_config` and `extends` directives, uses ad-hoc regular expression without `^/$` to avoid calling `parse`