### PR TITLE
Optimize FS cache

### DIFF
--- a/node.js
+++ b/node.js
@@ -387,7 +387,7 @@ module.exports = {
   },
 
   findConfigFile: function findConfigFile(from) {
-    var resolved = eachParent(from, function (dir) {
+    return eachParent(from, function (dir) {
       var config = path.join(dir, 'browserslist')
       var pkg = path.join(dir, 'package.json')
       var rc = path.join(dir, '.browserslistrc')
@@ -426,8 +426,6 @@ module.exports = {
     }, {
       cache: configPathCache
     })
-
-    return resolved
   },
 
   findConfig: function findConfig(from) {

--- a/node.js
+++ b/node.js
@@ -13,8 +13,6 @@ var FORMAT =
   'of strings with browser queries'
 
 var dataTimeChecked = false
-var filenessCache = {}
-var dirnessCache = {}
 var statCache = {}
 var configPathCache = {}
 var parseConfigCache = {}
@@ -39,24 +37,10 @@ function checkExtend(name) {
 }
 
 function isFile(file) {
-  if (file in filenessCache) {
-    return filenessCache[file]
-  }
-  var result = fs.existsSync(file) && fs.statSync(file).isFile()
-  if (!process.env.BROWSERSLIST_DISABLE_CACHE) {
-    filenessCache[file] = result
-  }
-  return result
+  return fs.existsSync(file) && fs.statSync(file).isFile()
 }
 function isDirectory(dir) {
-  if (dir in dirnessCache) {
-    return dirnessCache[dir]
-  }
-  var result = fs.existsSync(dir) && fs.statSync(dir).isDirectory()
-  if (!process.env.BROWSERSLIST_DISABLE_CACHE) {
-    dirnessCache[dir] = result
-  }
-  return result
+  return fs.existsSync(dir) && fs.statSync(dir).isDirectory()
 }
 
 function eachParent(file, callback, options) {
@@ -456,8 +440,6 @@ module.exports = {
 
   clearCaches: function clearCaches() {
     dataTimeChecked = false
-    filenessCache = {}
-    dirnessCache = {}
     statCache = {}
     configPathCache = {}
     parseConfigCache = {}

--- a/node.js
+++ b/node.js
@@ -431,8 +431,6 @@ module.exports = {
   },
 
   findConfig: function findConfig(from) {
-    from = path.resolve(from)
-
     var configFile = this.findConfigFile(from)
 
     return configFile ? parsePackageOrReadConfig(configFile) : undefined

--- a/node.js
+++ b/node.js
@@ -15,6 +15,7 @@ var FORMAT =
 var dataTimeChecked = false
 var filenessCache = {}
 var dirnessCache = {}
+var statCache = {}
 var configPathCache = {}
 var parseConfigCache = {}
 
@@ -284,7 +285,7 @@ module.exports = {
       stats = eachParent(opts.path, function (dir) {
         var file = path.join(dir, 'browserslist-stats.json')
         return isFile(file) ? file : undefined
-      })
+      }, { cache: statCache })
     }
     if (typeof stats === 'string') {
       try {
@@ -457,6 +458,7 @@ module.exports = {
     dataTimeChecked = false
     filenessCache = {}
     dirnessCache = {}
+    statCache = {}
     configPathCache = {}
     parseConfigCache = {}
 

--- a/node.js
+++ b/node.js
@@ -43,10 +43,9 @@ function isDirectory(dir) {
   return fs.existsSync(dir) && fs.statSync(dir).isDirectory()
 }
 
-function eachParent(file, callback, options) {
+function eachParent(file, callback, cache) {
   var loc = path.resolve(file)
-  var cache = options ? options.cache : false
-  var traceback = []
+  var pathsForCacheResult = []
   var result
   do {
     if (!pathInRoot(loc)) {
@@ -56,7 +55,7 @@ function eachParent(file, callback, options) {
       result = cache[loc]
       break
     }
-    traceback.push(loc)
+    pathsForCacheResult.push(loc)
     
     if (!isDirectory(loc)) {
       continue
@@ -70,7 +69,7 @@ function eachParent(file, callback, options) {
   } while (loc !== (loc = path.dirname(loc)))
   
   if (cache && !process.env.BROWSERSLIST_DISABLE_CACHE) {
-    traceback.forEach(function (cachePath) {
+    pathsForCacheResult.forEach(function (cachePath) {
       cache[cachePath] = result
     })
   }
@@ -267,7 +266,7 @@ module.exports = {
       stats = eachParent(opts.path, function (dir) {
         var file = path.join(dir, 'browserslist-stats.json')
         return isFile(file) ? file : undefined
-      }, { cache: statCache })
+      }, statCache)
     }
     if (typeof stats === 'string') {
       try {
@@ -411,9 +410,7 @@ module.exports = {
       } else if (pkgBrowserslist) {
         return pkg
       }
-    }, {
-      cache: configPathCache
-    })
+    }, configPathCache)
   },
 
   findConfig: function findConfig(from) {

--- a/node.js
+++ b/node.js
@@ -14,6 +14,7 @@ var FORMAT =
 
 var dataTimeChecked = false
 var filenessCache = {}
+var dirnessCache = {}
 var configPathCache = {}
 var parseConfigCache = {}
 
@@ -46,12 +47,22 @@ function isFile(file) {
   }
   return result
 }
+function isDirectory(dir) {
+  if (dir in dirnessCache) {
+    return dirnessCache[dir]
+  }
+  var result = fs.existsSync(dir) && fs.statSync(dir).isDirectory()
+  if (!process.env.BROWSERSLIST_DISABLE_CACHE) {
+    dirnessCache[dir] = result
+  }
+  return result
+}
 
 function eachParent(file, callback) {
-  var dir = isFile(file) ? path.dirname(file) : file
-  var loc = path.resolve(dir)
+  var loc = path.resolve(file)
   do {
     if (!pathInRoot(loc)) break
+    if (!isDirectory(loc)) continue
     var result = callback(loc)
     if (typeof result !== 'undefined') return result
   } while (loc !== (loc = path.dirname(loc)))
@@ -434,6 +445,7 @@ module.exports = {
   clearCaches: function clearCaches() {
     dataTimeChecked = false
     filenessCache = {}
+    dirnessCache = {}
     configPathCache = {}
     parseConfigCache = {}
 


### PR DESCRIPTION
Fixes #859 

Bundled a few things together:
1. Move cache from findConfigFile to eachParent, so that we
    1. Use cache if _any_ parent has been cached, not just on exact match of the first file / directory passed to `findConfig`
    2. Avoid a second `eachParent` pass to populate cache
    3. Avoid trouble when cache value exists, but is undefined, and won't terminate `eachParent` when returned from the callback
2. Add cache for `parsePackage` / `readConfig`, since `findConfigFile` caches paths, not content
3. Replaced `isFile` check in `eachParent` with explicit `isDirectory` check to optimize for virtual modules (path provided does not exist, is considered a directory, yields 3 fs checks for all kinds of config)
4. Added cache to `getStat` now that it's so easy with eachParent supporting cache
5. Removed `filenessCache` since `isFile` is only called within `eachParent`, and both `eachParent` calls now have explicit caches and will be called once for each directory

Tell me if I\ve gone too far, steps 1+2 already work pretty well.