### PR TITLE
docs: fix not found workleap logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can check how config works at our playground: [`browsersl.ist`](https://brow
 Browserslist needs your support. We are accepting donations
 [at Open Collective](https://opencollective.com/browserslist).
 
-<a href="https://www.springernature.com/"><img src="https://user-images.githubusercontent.com/19343/227742503-cf7fc2b3-9cc4-481c-97b8-68414d762fda.png" alt="Sponsored by Springer Nature Technology" width="154" height="54"></a>      <a href="https://workleap.com/"><img src="https://workleap.com/wp-content/uploads/2023/05/workleap-logo.svg" alt="Sponsored by Workleap" width="154" height="40"></a>
+<a href="https://www.springernature.com/"><img src="https://user-images.githubusercontent.com/19343/227742503-cf7fc2b3-9cc4-481c-97b8-68414d762fda.png" alt="Sponsored by Springer Nature Technology" width="154" height="54"></a>      <a href="https://workleap.com/"><img src="https://cdn.prod.website-files.com/66eab063c614790046e87eef/66f3c89500f8c53829f06098_Logotype.svg" alt="Sponsored by Workleap" width="154" height="40"></a>
 
 
 ## Tools


### PR DESCRIPTION
# Description

The [current workleap logo](https://workleap.com/wp-content/uploads/2023/05/workleap-logo.svg) doesn't show correctly in [README.md](https://github.com/browserslist/browserslist/blob/main/README.md) due to expired link.
Therefore I updated the image to see it.

## After

![after](https://github.com/user-attachments/assets/935a25f2-5f01-4d2a-b658-924a5ac12c98)

## Before

![before](https://github.com/user-attachments/assets/7d93ac65-e08e-4acc-9e08-912a8db5b8b8)
