### PR TITLE
fix: handle ErrnoExceptions in isFile() and isDirectory()

### DIFF
--- a/node.js
+++ b/node.js
@@ -39,7 +39,7 @@ function checkExtend(name) {
   }
 }
 
-function _getPathType(filepath) {
+function getPathType(filepath) {
   var stats
   try {
     stats = fs.existsSync(filepath) && fs.statSync(filepath)
@@ -64,11 +64,11 @@ function _getPathType(filepath) {
 }
 
 function isFile(file) {
-  return _getPathType(file) === PATHTYPE_FILE
+  return getPathType(file) === PATHTYPE_FILE
 }
 
 function isDirectory(dir) {
-  return _getPathType(dir) === PATHTYPE_DIR
+  return getPathType(dir) === PATHTYPE_DIR
 }
 
 function eachParent(file, callback, cache) {


### PR DESCRIPTION
Handle select ErrnoException errors gracefully in `isFile()` and `isDirectory()`

Note: unit tests all pass, but `test:lint` fails for me.  It fails on `main` as well, though, so I assume it's unrelated to this PR.  Maybe just something to do with my environment?

```bash
$ pnpm test:lint

> browserslist@4.25.1 test:lint /Users/kieffer/repos/browserslist
> eslint .


/Users/kieffer/repos/browserslist/eslint.config.mjs
  1:1  error  Resolve error: node with invalid interface loaded as resolver  import-x/no-duplicates

✖ 1 problem (1 error, 0 warnings)

 ELIFECYCLE  Command failed with exit code 1.
```

Fixes #899 
