### PR TITLE
Fix loadStat creating a non-working module path on Windows

### DIFF
--- a/node.js
+++ b/node.js
@@ -279,7 +279,8 @@ module.exports = {
       checkExtend(name)
     }
     var stats = require(
-      require.resolve(path.join(name, 'browserslist-stats.json'), {
+      // Use forward slashes for module paths, also on Windows.
+      require.resolve(path.posix.join(name, 'browserslist-stats.json'), {
         paths: ['.']
       })
     )


### PR DESCRIPTION
Fixes https://github.com/browserslist/browserslist/issues/901