### PR TITLE
feat: allow esr alias in firefox version ranges

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var parseWithoutCache = require('./parse') // Will load browser.js in webpack
 var YEAR = 365.259641 * 24 * 60 * 60 * 1000
 var ANDROID_EVERGREEN_FIRST = '37'
 var OP_MOB_BLINK_FIRST = 14
+var FIREFOX_ESR_VERSION = '140'
 
 // Helpers
 
@@ -1109,12 +1110,13 @@ var QUERIES = {
   },
   browser_ray: {
     matches: ['browser', 'sign', 'version'],
-    regexp: /^(\w+)\s*(>=?|<=?)\s*([\d.]+)$/,
+    regexp: /^(\w+)\s*(>=?|<=?)\s*([\d.]+|esr)$/i,
     select: function (context, node) {
       var version = node.version
       var data = checkName(node.browser, context)
-      var alias = browserslist.versionAliases[data.name][version]
+      var alias = browserslist.versionAliases[data.name][version.toLowerCase()]
       if (alias) version = alias
+      if (!/[\d.]+/.test(version)) throw new BrowserslistError('Unknown version ' + version + ' of ' + node.browser);
       return data.released
         .filter(generateFilter(node.sign, version))
         .map(function (v) {
@@ -1126,7 +1128,7 @@ var QUERIES = {
     matches: [],
     regexp: /^(firefox|ff|fx)\s+esr$/i,
     select: function () {
-      return ['firefox 140']
+      return ['firefox ' + FIREFOX_ESR_VERSION]
     }
   },
   opera_mini_all: {
@@ -1319,5 +1321,7 @@ var QUERIES = {
     return release.version
   })
 })()
+
+browserslist.versionAliases.firefox.esr = FIREFOX_ESR_VERSION
 
 module.exports = browserslist

--- a/test/esr.test.js
+++ b/test/esr.test.js
@@ -1,5 +1,5 @@
 let { test } = require('uvu')
-let { equal, is } = require('uvu/assert')
+let { equal, is, throws } = require('uvu/assert')
 
 delete require.cache[require.resolve('..')]
 let browserslist = require('..')
@@ -13,11 +13,28 @@ test('selects Firefox ESR', () => {
   )
 })
 
+test('can use esr in version range for firefox', () => {
+  let versions = browserslist('Firefox >= ESR')
+  is(versions.length >= 1, true)
+  is(
+    versions.every(i => /^firefox \d+$/.test(i)),
+    true
+  )
+})
+
 test('uses case insensitive aliases', () => {
   let result = browserslist('Firefox ESR')
   equal(browserslist('firefox esr'), result)
   equal(browserslist('ff esr'), result)
   equal(browserslist('fx esr'), result)
+  equal(browserslist('ff >= esr and fx <= esr'), result)
+})
+
+test('throw error when using esr in range for unsupported browsers', () => {
+  throws(
+    () => browserslist('Chrome >= ESR'),
+    /Unknown version ESR of Chrome/
+  )
 })
 
 test.run()


### PR DESCRIPTION
As of this message, Firefox ESR is an alias for Firefox 140. However, as Firefox ESR is treated as its own browser, it's not possible to use this in version ranges as far as I know.

This works already, which is effectively the same as Firefox 140:

```
Firefox ESR
```

This does not work, which I'd expect it to be the same as Firefox >= 140:

```
Firefox >= ESR
```

Would you allow `ESR` to be an acceptable alias in `browser_ray` as well? Then `ESR` will be mapped to Firefox 140 when both specifying the browser but also in version ranges.

## Use Case

For [SVGO.dev](https://svgo.dev), as the website is aimed at developers, I'm looking at only supporting modern browsers.

I'm thinking a browserslist query like this, which has 86.9% global coverage, or 93.85~% coverage from my stats:

```
baseline widely available and not Firefox >= 0
Firefox >= ESR
not dead
```