### PR TITLE
Update Node.js Foundation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ You can specify the browser and Node.js versions by queries (case insensitive):
   * `last 2 node major versions`: select 2 latest major-version Node.js releases.
   * `current node`: Node.js version used by Browserslist right now.
   * `maintained node versions`: all Node.js versions, which are [still maintained]
-    by the OpenJS Foundation and Node.js project.
+    by the Node.js team.
 * Browsers versions:
   * `iOS 7`: the iOS browser version 7 directly. Note, that `op_mini`
     has special version `all`.


### PR DESCRIPTION
Node.js Foundation is now (and has been for a while) apart of the OpenJS Foundation.