### PR TITLE
Fix: treat baseline newly/widely available keywords case-insensitively

### DIFF
--- a/index.js
+++ b/index.js
@@ -829,7 +829,8 @@ var QUERIES = {
       var baselineVersions
       var includeDownstream = !!node.downstream
       var includeKaiOS = !!node.kaios
-      if (node.availability === 'newly' && node.date) {
+      var availability = node.availability && node.availability.toLowerCase()
+      if (availability === 'newly' && node.date) {
         throw new BrowserslistError(
           'Using newly available with a date is not supported, please use "widely available on YYYY-MM-DD" and add 30 months to the date you specified.'
         )
@@ -848,7 +849,7 @@ var QUERIES = {
           includeKaiOS: includeKaiOS,
           suppressWarnings: true
         })
-      } else if (node.availability === 'newly') {
+      } else if (availability === 'newly') {
         var future30months = new Date().setMonth(new Date().getMonth() + 30)
         baselineVersions = bbm.getCompatibleVersions({
           widelyAvailableOnDate: future30months,

--- a/test/baseline.test.js
+++ b/test/baseline.test.js
@@ -116,4 +116,16 @@ test('Throws an error when "newly available on YYYY-MM-DD" is used', () => {
   }, /Using newly available with a date is not supported/)
 })
 
+// Test case insensitivity
+test('Treats "newly available" as case insensitive', () => {
+  equal(
+    browserslist('BASELINE NEWLY AVAILABLE'),
+    browserslistBaselineNewly
+  )
+  equal(
+    browserslist('baseline NEWLY available'),
+    browserslistBaselineNewly
+  )
+})
+
 test.run()


### PR DESCRIPTION
The baseline query regexp already matched case-insensitively, but the select function compared node.availability against lowercase literals, so e.g. "BASELINE NEWLY AVAILABLE" fell through to the default (widely available) branch instead of newly available.

Fixes #932