### PR TITLE
fix: exclude joined range when querying above its upper bound

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,22 +81,21 @@ function fillUsage(result, name, data) {
 }
 
 function generateFilter(sign, version) {
-  version = parseFloat(version)
   if (sign === '>') {
     return function (v) {
-      return parseLatestFloat(v) > version
+      return parseLatestFloat(v) > parseLatestFloat(version)
     }
   } else if (sign === '>=') {
     return function (v) {
-      return parseLatestFloat(v) >= version
+      return parseLatestFloat(v) >= parseLatestFloat(version)
     }
   } else if (sign === '<') {
     return function (v) {
-      return parseFloat(v) < version
+      return parseFloat(v) < parseFloat(version)
     }
   } else {
     return function (v) {
-      return parseFloat(v) <= version
+      return parseFloat(v) <= parseFloat(version)
     }
   }
 

--- a/test/versions.test.js
+++ b/test/versions.test.js
@@ -88,4 +88,9 @@ test('selects browser lte or lt between version range', () => {
   equal(browserslist('ios < 15.7.2'), ['ios_saf 15.6-15.8', 'ios_saf 15.0'])
 })
 
+test('excludes range when gt upper bound of that range', () => {
+  equal(browserslist('ios > 15.8'), ['ios_saf 16.0'])
+  equal(browserslist('ios >= 15.8'), ['ios_saf 16.0', 'ios_saf 15.6-15.8'])
+})
+
 test.run()


### PR DESCRIPTION
### Problem

A `>` or `>=` version query against a caniuse joined range wrongly includes the range it should exclude.

### Repro

```js
browserslist('ios_saf > 15.8')  // includes "ios_saf 15.6-15.8"  (should not)
browserslist('ios_saf >= 15.8') // includes "ios_saf 15.6-15.8"  (correct)
```

No version inside `15.6-15.8` is strictly greater than `15.8`, so `> 15.8` must exclude that range, while `>= 15.8` must include it. Today both include it.

### Root cause

`browser_ray` resolves the query version through `versionAliases`, so a boundary version that is the upper bound of a joined range (e.g. `15.8`) is substituted with the full range string `15.6-15.8` before it reaches `generateFilter(sign, version)`. There the threshold was computed with `parseFloat("15.6-15.8")`, which collapses the range to its lower bound `15.6` regardless of the operator. So `> 15.8` behaved like `> 15.6`, and the candidate `15.6-15.8` (latest `15.8`) satisfied `15.8 > 15.6` and was kept.

PR #836 fixed the candidate side (`>`/`>=` compare each candidate by its latest released version via `parseLatestFloat`) but left the threshold side using plain `parseFloat`, so the same range collapse still happened for the query version. Its tests used a patch version (`15.7.2`), which is not an alias key, so this path was never exercised.

### Fix

Parse the threshold per branch the same way the candidate already is, so the comparison stays range-aware:

- `>` and `>=`: `parseLatestFloat(version)` (upper bound of the range alias)
- `<` and `<=`: `parseFloat(version)` (unchanged)

Plain-number thresholds and the firefox `esr` threshold contain no `-`, so their behavior is unchanged.

### Authority

Range-inclusion semantics come from the repo's own version tests: a joined range is included iff some version in it satisfies the operator. The existing lt/lte range tests remain green; a new test asserts `> 15.8` excludes `15.6-15.8` while `>= 15.8` includes it.

### Verification

- New test fails on the current threshold behavior and passes with the fix.
- `<`/`<=` queries produce byte-identical output before and after (verified via A/B on `ios_saf < 15.8`, `chrome <= 100`, `firefox < 50`, `ios_saf <= 15.8`).
- Full uvu suite: 300/300 passing, 100% statement/line coverage.
