### PR TITLE
fix: compare Electron range bounds as semver

### DIFF
--- a/index.js
+++ b/index.js
@@ -1058,10 +1058,8 @@ var QUERIES = {
         throw new BrowserslistError('Unknown version ' + to + ' of electron')
       }
       return Object.keys(e2c)
-        .filter(function (i) {
-          var parsed = parseFloat(i)
-          return parsed >= from && parsed <= to
-        })
+        .filter(semverFilterLoose('>=', node.from))
+        .filter(semverFilterLoose('<=', node.to))
         .map(function (i) {
           return 'chrome ' + e2c[i]
         })

--- a/test/electron.test.js
+++ b/test/electron.test.js
@@ -42,6 +42,10 @@ test('throws on unknown Electron range version', () => {
   throws(() => browserslist('electron 0.37-999'), /Unknown version/)
 })
 
+test('compares Electron range bounds as semver', () => {
+  equal(browserslist('electron 37.9 - 37.10'), ['chrome 138'])
+})
+
 test('converts Electron versions to Chrome', () => {
   equal(browserslist('electron <= 0.21'), ['chrome 41', 'chrome 39'])
 })


### PR DESCRIPTION
`electron_range` compared version bounds with `parseFloat`, which reads a minor component like `37.10` as `37.1`. Once a minor reaches two digits the comparison breaks:

```js
browserslist('electron 37.9 - 37.10') // []   (should be ['chrome 138'])
browserslist('electron 37.2 - 37.10') // []   (should be ['chrome 138'])
```

`parseFloat('37.10')` is `37.1`, so the upper bound lands below the lower bound and the range matches nothing; a wider range like `37.2 - 37.10` silently drops `37.2`-`37.9`. electron-to-chromium already ships such versions (`37.10`, `40.10`, `41.10`).

Fix: filter with `semverFilterLoose`, the same helper `node_range` already uses, so minor components compare as integers rather than decimals. Patch handling and the missing-minor case are unchanged, and the existing throw-on-unknown-version behavior is kept.

Adds a regression test.
