### PR TITLE
fix: support "including kaios" without downstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ You can specify the browser and Node.js versions by queries (case insensitive):
   - `baseline widely available on YYYY-MM-DD`: selects browser versions that supported the Widely available feature set on the specified date.
   - `baseline 2022`: selects browser versions that are compatible with all features that were Baseline Newly available at the end of the specified year.
   - `… with downstream`: includes browsers outside the core browser set that support the requested Baseline feature set based on their Chromium or Gecko version. See [`baseline-browser-mapping`](https://github.com/web-platform-dx/baseline-browser-mapping#downstream-browsers).
-  - `… with downstream including kaios`: same output as the previous query plus KaiOS.
+  - `… including kaios`: adds KaiOS, with or without `with downstream`.
 - Last versions:
   - `last 2 versions`: the last 2 versions for _each_ browser.
   - `last 2 Chrome versions`: the last 2 versions of Chrome browser.

--- a/grammar.w3c-ebnf
+++ b/grammar.w3c-ebnf
@@ -54,7 +54,7 @@ Years ::= 'last' Space+ Numeric Space+ 'year' 's'?
 
 Since ::= 'since' Space Digit+ ('-' Digit+ ('-' Digit+)?)?
 
-Baseline ::= 'baseline' Space (Digit+ | ('newly' | 'widely') Space 'available' (Space 'on' Space Digit+ ('-' Digit+ ('-' Digit+)?)?)? (' with downstream')? (' including kaios')?)
+Baseline ::= 'baseline' Space (Digit+ | ('newly' | 'widely') Space 'available' (Space 'on' Space Digit+ ('-' Digit+ ('-' Digit+)?)?)?) (Space 'with' Space 'downstream')? (Space 'including' Space 'kaios')?
 
 Region ::= ('alt-' [a-z][a-z] | [A-Z][A-Z])
 

--- a/index.js
+++ b/index.js
@@ -834,43 +834,44 @@ var QUERIES = {
     regexp:
       /^baseline\s+(?!\s)(?:(\d+)|(newly|widely)\s+(?!\s)available(?:\s+(?!\s)on\s+(?!\s)(\d{4}-\d{2}-\d{2}))?)?(\s+(?!\s)with\s+(?!\s)downstream)?(\s+(?!\s)including\s+(?!\s)kaios)?$/i,
     select: function (context, node) {
-      var baselineVersions
-      var includeDownstream = !!node.downstream
-      var includeKaiOS = !!node.kaios
       var availability = node.availability && node.availability.toLowerCase()
       if (availability === 'newly' && node.date) {
         throw new BrowserslistError(
           'Using newly available with a date is not supported, please use "widely available on YYYY-MM-DD" and add 30 months to the date you specified.'
         )
       }
+
+      var options = {
+        includeDownstreamBrowsers: !!node.downstream,
+        includeKaiOS: !!node.kaios,
+        suppressWarnings: true
+      }
       if (node.year) {
-        baselineVersions = bbm.getCompatibleVersions({
-          targetYear: node.year,
-          includeDownstreamBrowsers: includeDownstream,
-          includeKaiOS: includeKaiOS,
-          suppressWarnings: true
-        })
+        options.targetYear = node.year
       } else if (node.date) {
-        baselineVersions = bbm.getCompatibleVersions({
-          widelyAvailableOnDate: node.date,
-          includeDownstreamBrowsers: includeDownstream,
-          includeKaiOS: includeKaiOS,
-          suppressWarnings: true
-        })
+        options.widelyAvailableOnDate = node.date
       } else if (availability === 'newly') {
-        var future30months = new Date().setMonth(new Date().getMonth() + 30)
-        baselineVersions = bbm.getCompatibleVersions({
-          widelyAvailableOnDate: future30months,
-          includeDownstreamBrowsers: includeDownstream,
-          includeKaiOS: includeKaiOS,
-          suppressWarnings: true
-        })
+        options.widelyAvailableOnDate = new Date().setMonth(
+          new Date().getMonth() + 30
+        )
+      }
+
+      var baselineVersions
+      if (options.includeKaiOS && !options.includeDownstreamBrowsers) {
+        // baseline-browser-mapping counts KaiOS as a downstream browser and
+        // refuses to return it alone, so take KaiOS from the downstream list
+        // and everything else from the core one
+        options.includeDownstreamBrowsers = true
+        var downstream = bbm.getCompatibleVersions(options)
+        options.includeDownstreamBrowsers = false
+        options.includeKaiOS = false
+        baselineVersions = bbm.getCompatibleVersions(options).concat(
+          downstream.filter(function (version) {
+            return version.browser === 'kai_os'
+          })
+        )
       } else {
-        baselineVersions = bbm.getCompatibleVersions({
-          includeDownstreamBrowsers: includeDownstream,
-          includeKaiOS: includeKaiOS,
-          suppressWarnings: true
-        })
+        baselineVersions = bbm.getCompatibleVersions(options)
       }
       return resolve(bbmTransform(baselineVersions), context)
     }

--- a/test/baseline.test.js
+++ b/test/baseline.test.js
@@ -109,6 +109,40 @@ test('Selects proper downstream versions for baseline 2020', () => {
   )
 })
 
+// Test KaiOS without the other downstream browsers
+test('Adds KaiOS and nothing else when downstream is not requested', () => {
+  let core = browserslist('baseline 2020')
+  let withKaiOS = browserslist('baseline 2020 including kaios')
+  equal(
+    withKaiOS.filter(browser => core.indexOf(browser) === -1),
+    ['kaios 3.0-3.1']
+  )
+  equal(
+    core.filter(browser => withKaiOS.indexOf(browser) === -1),
+    []
+  )
+})
+
+test('Accepts "including kaios" without downstream in every baseline shape', () => {
+  let queries = [
+    'baseline widely available',
+    'baseline newly available',
+    'baseline 2020',
+    'baseline widely available on 2022-07-01'
+  ]
+  for (let query of queries) {
+    let core = browserslist(query)
+    let extra = browserslist(query + ' including kaios').filter(
+      browser => core.indexOf(browser) === -1
+    )
+    is(
+      extra.every(browser => browser.indexOf('kaios ') === 0),
+      true,
+      `${query} added ${extra}`
+    )
+  }
+})
+
 // Test for errors
 test('Throws an error when "newly available on YYYY-MM-DD" is used', () => {
   throws(() => {
@@ -118,14 +152,8 @@ test('Throws an error when "newly available on YYYY-MM-DD" is used', () => {
 
 // Test case insensitivity
 test('Treats "newly available" as case insensitive', () => {
-  equal(
-    browserslist('BASELINE NEWLY AVAILABLE'),
-    browserslistBaselineNewly
-  )
-  equal(
-    browserslist('baseline NEWLY available'),
-    browserslistBaselineNewly
-  )
+  equal(browserslist('BASELINE NEWLY AVAILABLE'), browserslistBaselineNewly)
+  equal(browserslist('baseline NEWLY available'), browserslistBaselineNewly)
 })
 
 test.run()


### PR DESCRIPTION
Rewritten to make the query work instead of rejecting it, per review.

## The bug

`baseline … including kaios` **without** `with downstream` never returns KaiOS.
What it does instead depends on which `baseline-browser-mapping` you resolved:

| `baseline-browser-mapping` | `baseline widely available including kaios` |
| --- | --- |
| `2.10.44` (what `pnpm-lock.yaml` pins, so what CI runs) | `process.exit(1)` |
| `2.11.12` (what `^2.10.44` resolves to today) | silently identical to `baseline widely available` |

`select()` forwards `includeKaiOS` and `includeDownstreamBrowsers`
independently, and `baseline-browser-mapping` refuses that pair. Up to 2.10.44
it refused with `console.log(new Error(…))` followed by `process.exit(1)` — not
a throw, so nothing was catchable and `suppressWarnings: true` did not help.
Any tool resolving the config (webpack, Babel, Autoprefixer, Stylelint) just
died with exit 1 and an error on **stdout**. 2.11.x turned that into a real
`Error`, but only in `getAllVersions`/`getTimeline`; `getCompatibleVersions`,
the one we call, now drops KaiOS without a word.

So on current npm the query is a silent no-op, and on the locked version it is
fatal. Both are wrong, and a user pinning either can hit either.

## The fix

KaiOS is downstream *in `baseline-browser-mapping`'s model*, but from
Browserslist's side there is nothing incoherent about "core browsers plus
KaiOS" — the mapping just has no way to express it. So ask for the whole
downstream set, keep KaiOS out of it, and merge that onto the core set:

```js
options.includeDownstreamBrowsers = true
var downstream = bbm.getCompatibleVersions(options)
options.includeDownstreamBrowsers = false
options.includeKaiOS = false
baselineVersions = bbm.getCompatibleVersions(options).concat(
  downstream.filter(function (version) {
    return version.browser === 'kai_os'
  })
)
```

`baseline 2020 including kaios` is now exactly `baseline 2020` plus
`kaios 3.0-3.1` — no `samsung`, `opera`, `and_uc`, `and_qq` or `android`. The
extra call only happens for this one query shape; every other query still makes
exactly one.

The four `getCompatibleVersions` call sites differed only in a single key, so
they are now one options object built up in the branches. That is what makes
the KaiOS case a small addition rather than a fifth copy.

`grammar.w3c-ebnf` keeps `with downstream` and `including kaios` independently
optional, which is now true, and moves both outside the year/availability
alternation — they had been attached only to the `newly`/`widely` branch, while
the regexp and the existing `baseline 2020 with downstream including kaios`
test already allowed them on both.

## A related limitation, not fixed here

`including kaios` only produces output for older baselines.
`baseline-browser-mapping` reports `kai_os 4.0` for anything from ~2021 on,
`caniuse-lite`'s `kaios` tops out at `3.0-3.1`, so `kaios >= 4.0` resolves to
nothing. That is true of `with downstream including kaios` on `main` today too
— `baseline widely available with downstream including kaios` contains no
`kaios` entry. It is a caniuse data gap rather than a query bug, so I left it
alone, but it is why the new tests use `baseline 2020`.

## Verification

- `Adds KaiOS and nothing else when downstream is not requested` asserts the
  set difference in both directions against `baseline 2020`: exactly
  `['kaios 3.0-3.1']` added, nothing dropped. On `main` + 2.11.12 it fails with
  a one-line diff (KaiOS missing).
- `Accepts "including kaios" without downstream in every baseline shape` covers
  all four shapes. On `main` + the locked 2.10.44 the suite does not fail, it
  **aborts** — uvu prints `Exiting early before testing is finished`.
- `unit` — 304 passed, against **both** `baseline-browser-mapping@2.10.44` and
  `@2.11.12`.
- `test:lint` — clean; `oxfmt --check` clean on both changed files.
- `test:coverage` — statements/lines/functions 100%. Branches 98.89%, the same
  as `main`, with the same two uncovered lines (375, 550).
- `test:size` — 24.96 kB against the 30 kB limit (24.89 kB on `main`).

README now documents `… including kaios` on its own rather than only as a
suffix of `… with downstream`. `CHANGELOG.md` left alone, matching #937/#938 —
happy to add an entry.
