### PR TITLE
docs: fix typo in table rendering for `SECURITY.md`

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@
 Only the latest release is supported.
 
 | Version  | Supported          |
-| ------- -| ------------------ |
+| -------- | ------------------ |
 | 4.28.2   | :white_check_mark: |
 | < 4.28.2 | :x:                |
 


### PR DESCRIPTION
## Summary

Fixed a typo in the `SECURITY.md` table markdown

## Details

- stumbled upon [this rendering issue](https://github.com/browserslist/browserslist/security) while reading the latest CVEs (due to https://github.com/suttacentral/suttacentral/pull/3733)
  - the whole table was on one line and in plain text due to the misplacement of a dash
  
## Verification

Can look at the rich diff of the PR/commit and it shows the one-line plaintext vs. the properly rendered table now